### PR TITLE
Add type hint inside compile-element

### DIFF
--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -446,6 +446,7 @@
 
 (defmethod compile-element :component [v]
   (let [[tag & args] v
+        tag (vary-meta tag assoc :tag 'js)
         args (mapv compile-html* args)]
     `(do
        (set! (.-compiled? ~tag) true)


### PR DESCRIPTION
Fixes

<img width="679" alt="Screenshot 2021-09-09 at 15 04 36" src="https://user-images.githubusercontent.com/2881251/132694207-0c753194-2228-4a75-af66-d5e6d1b671f1.png">

For some reason, this only happens after code reload. This is why we missed it in the first set of type hint fixes we applied.