### PR TITLE
interpret dynamic dom attributes

### DIFF
--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -4,17 +4,6 @@
             [uix.compiler.js :as js]
             [uix.compiler.attributes :as attrs]))
 
-(defn check-attrs [v attrs children expr]
-  (if (and (nil? attrs) (symbol? (first children)))
-    `(let [m# ~(first children)]
-       (assert (not (map? m#))
-               (str "Looks like you've passed a dynamic map of props " m#
-                    " in " ~(str v) " form. "
-                    "Dynamic props are not supported in UIx's pre-compilation mode. "
-                    "Make sure to declare props explicitly as map literal."))
-       ~expr)
-    expr))
-
 ;; Compiles Hiccup into React.createElement
 (defmulti compile-element
   (fn [[tag]]
@@ -31,11 +20,17 @@
         id-class (attrs/parse-tag tag)
         tag (first id-class)
         m (meta v)
-        attrs (cond-> attrs
-                :always (attrs/set-id-class id-class)
-                (:key m) (assoc :key (:key m))
-                (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs))))
-        attrs (js/to-js (attrs/compile-attrs attrs {:custom-element? (re-find #"-" tag)}))
+        attrs (if-not (map? attrs)
+                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false)
+                (cond-> attrs
+                  :always (attrs/set-id-class id-class)
+                  (:key m) (assoc :key (:key m))
+                  (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
+                  (and (some? (:style attrs))
+                       (not (map? (:style attrs))))
+                  (assoc :style `(uix.compiler.attributes/interpret-attrs ~(:style attrs) (cljs.core/array) true))
+                  :always (attrs/compile-attrs {:custom-element? (re-find #"-" tag)})
+                  :always js/to-js))
         ret `(>el ~tag ~attrs ~@children)]
     ret))
 
@@ -47,18 +42,24 @@
 (defmethod compile-element :fragment [v]
   (let [[_ attrs & children] v
         m (meta v)
-        attrs (cond-> attrs
-                (:key m) (assoc :key (:key m)))
-        attrs (js/to-js (attrs/compile-attrs attrs))
+        attrs (if-not (map? attrs)
+                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
+                (cond-> attrs
+                  (:key m) (assoc :key (:key m))
+                  :always attrs/compile-attrs
+                  :always js/to-js))
         ret `(>el fragment ~attrs ~@children)]
     ret))
 
 (defmethod compile-element :suspense [v]
   (let [[_ attrs & children] v
         m (meta v)
-        attrs (cond-> attrs
-                (:key m) (assoc :key (:key m)))
-        attrs (js/to-js (attrs/compile-attrs attrs))
+        attrs (if-not (map? attrs)
+                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
+                (cond-> attrs
+                  (:key m) (assoc :key (:key m))
+                  :always attrs/compile-attrs
+                  :always js/to-js))
         ret `(>el suspense ~attrs ~children)]
     ret))
 
@@ -71,10 +72,13 @@
 (defmethod compile-element :interop [v]
   (let [[tag attrs & children] v
         m (meta v)
-        attrs (cond-> attrs
-                (:key m) (assoc :key (:key m))
-                (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs))))
-        attrs (js/to-js (attrs/compile-attrs attrs))]
+        attrs (if-not (map? attrs)
+                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) true)
+                (cond-> attrs
+                  (:key m) (assoc :key (:key m))
+                  (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
+                  :always attrs/compile-attrs
+                  :always js/to-js))]
     `(>el ~tag ~attrs ~children)))
 
 (defn compile-html

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -73,7 +73,7 @@
     `(~'js/ReactDOM.createPortal ~child ~node)))
 
 (defmethod compile-element :interop [v]
-  (let [[tag attrs & children] v
+  (let [[_ tag attrs & children] v
         m (meta v)
         attrs (when (some? attrs)
                 (if-not (map? attrs)

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -20,17 +20,18 @@
         id-class (attrs/parse-tag tag)
         tag (first id-class)
         m (meta v)
-        attrs (if-not (map? attrs)
-                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false)
-                (cond-> attrs
-                  :always (attrs/set-id-class id-class)
-                  (:key m) (assoc :key (:key m))
-                  (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
-                  (and (some? (:style attrs))
-                       (not (map? (:style attrs))))
-                  (assoc :style `(uix.compiler.attributes/interpret-attrs ~(:style attrs) (cljs.core/array) true))
-                  :always (attrs/compile-attrs {:custom-element? (re-find #"-" tag)})
-                  :always js/to-js))
+        attrs (when (some? attrs)
+                (if-not (map? attrs)
+                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false)
+                  (cond-> attrs
+                    :always (attrs/set-id-class id-class)
+                    (:key m) (assoc :key (:key m))
+                    (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
+                    (and (some? (:style attrs))
+                         (not (map? (:style attrs))))
+                    (assoc :style `(uix.compiler.attributes/interpret-attrs ~(:style attrs) (cljs.core/array) true))
+                    :always (attrs/compile-attrs {:custom-element? (re-find #"-" tag)})
+                    :always js/to-js)))
         ret `(>el ~tag ~attrs ~@children)]
     ret))
 
@@ -42,24 +43,26 @@
 (defmethod compile-element :fragment [v]
   (let [[_ attrs & children] v
         m (meta v)
-        attrs (if-not (map? attrs)
-                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
-                (cond-> attrs
-                  (:key m) (assoc :key (:key m))
-                  :always attrs/compile-attrs
-                  :always js/to-js))
+        attrs (when (some? attrs)
+                (if-not (map? attrs)
+                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
+                  (cond-> attrs
+                    (:key m) (assoc :key (:key m))
+                    :always attrs/compile-attrs
+                    :always js/to-js)))
         ret `(>el fragment ~attrs ~@children)]
     ret))
 
 (defmethod compile-element :suspense [v]
   (let [[_ attrs & children] v
         m (meta v)
-        attrs (if-not (map? attrs)
-                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
-                (cond-> attrs
-                  (:key m) (assoc :key (:key m))
-                  :always attrs/compile-attrs
-                  :always js/to-js))
+        attrs (when (some? attrs)
+                (if-not (map? attrs)
+                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
+                  (cond-> attrs
+                    (:key m) (assoc :key (:key m))
+                    :always attrs/compile-attrs
+                    :always js/to-js)))
         ret `(>el suspense ~attrs ~children)]
     ret))
 
@@ -72,13 +75,14 @@
 (defmethod compile-element :interop [v]
   (let [[tag attrs & children] v
         m (meta v)
-        attrs (if-not (map? attrs)
-                `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) true)
-                (cond-> attrs
-                  (:key m) (assoc :key (:key m))
-                  (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
-                  :always attrs/compile-attrs
-                  :always js/to-js))]
+        attrs (when (some? attrs)
+                (if-not (map? attrs)
+                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) true)
+                  (cond-> attrs
+                    (:key m) (assoc :key (:key m))
+                    (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
+                    :always attrs/compile-attrs
+                    :always js/to-js)))]
     `(>el ~tag ~attrs ~children)))
 
 (defn compile-html

--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -1,7 +1,8 @@
 (ns uix.compiler.aot
   "Runtime helpers for Hiccup compiled into React.js"
   (:require [react :as react]
-            [uix.compiler.alpha :as r]))
+            [uix.compiler.alpha :as r]
+            [uix.compiler.attributes]))
 
 (def >el react/createElement)
 (def suspense react/Suspense)

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -1,0 +1,180 @@
+(ns uix.compiler.attributes
+  (:require [clojure.string :as str]
+            [goog.object :as gobj]))
+
+(declare convert-prop-value)
+(declare convert-prop-value-shallow)
+
+(defn js-val? [x]
+  (not (identical? "object" (goog/typeOf x))))
+
+(def prop-name-cache
+  #js {:class "className"
+       :for "htmlFor"
+       :charset "charSet"})
+
+(def custom-prop-name-cache #js {})
+
+(def tag-name-cache #js {})
+
+(def ^:private cc-regexp (js/RegExp. "-(\\w)" "g"))
+
+(defn- cc-fn [s]
+  (str/upper-case (aget s 1)))
+
+(defn ^string dash-to-camel [^string name-str]
+  (if (or (str/starts-with? name-str "aria-")
+          (str/starts-with? name-str "data-"))
+    name-str
+    (.replace name-str cc-regexp cc-fn)))
+
+(defn cached-prop-name [k]
+  (if (keyword? k)
+    (let [name-str (-name ^not-native k)]
+      (if-some [k' (aget prop-name-cache name-str)]
+        k'
+        (let [v (dash-to-camel name-str)]
+          (aset prop-name-cache name-str v)
+          v)))
+    k))
+
+(defn cached-custom-prop-name [k]
+  (if (keyword? k)
+    (let [name-str (-name ^not-native k)]
+      (if-some [k' (aget custom-prop-name-cache name-str)]
+        k'
+        (let [v (dash-to-camel name-str)]
+          (aset custom-prop-name-cache name-str v)
+          v)))
+    k))
+
+(defn convert-interop-prop-value [k v]
+  (cond
+    (= k :style) (if (vector? v)
+                   (-reduce ^not-native v
+                            (fn [a v]
+                              (.push a (convert-prop-value-shallow v))
+                              a)
+                            #js [])
+                   (convert-prop-value-shallow v))
+    (keyword? v) (-name ^not-native v)
+    :else v))
+
+(defn kv-conv [o k v]
+  (gobj/set o (cached-prop-name k) (convert-prop-value v))
+  o)
+
+(defn kv-conv-shallow [o k v]
+  (gobj/set o (cached-prop-name k) (convert-interop-prop-value k v))
+  o)
+
+(defn custom-kv-conv [o k v]
+  (gobj/set o (cached-custom-prop-name k) (convert-prop-value v))
+  o)
+
+(defn convert-prop-value [x]
+  (cond
+    (js-val? x) x
+    (keyword? x) (-name ^not-native x)
+    (map? x) (reduce-kv kv-conv #js {} x)
+    (coll? x) (clj->js x)
+    (ifn? x) #(apply x %&)
+    :else (clj->js x)))
+
+(defn convert-custom-prop-value [x]
+  (cond
+    (js-val? x) x
+    (keyword? x) (-name ^not-native x)
+    (map? x) (reduce-kv custom-kv-conv #js {} x)
+    (coll? x) (clj->js x)
+    (ifn? x) #(apply x %&)
+    :else (clj->js x)))
+
+(defn convert-prop-value-shallow [x]
+  (if (map? x)
+    (reduce-kv kv-conv-shallow #js {} x)
+    x))
+
+(defn class-names-coll [class]
+  (let [^js/Array classes (reduce (fn [^js/Array a c]
+                                    (when ^boolean c
+                                      (->> (if (keyword? c) (-name ^not-native c) c)
+                                           (.push a)))
+                                    a)
+                                  #js []
+                                  class)]
+    (when (pos? (.-length classes))
+      (.join classes " "))))
+
+(defn class-names-map [class]
+  (let [^js/Array classes (reduce-kv (fn [^js/Array a b ^boolean c]
+                                       (when c
+                                         (->> (if (keyword? b) (-name ^not-native b) b)
+                                              (.push a)))
+                                       a)
+                                     #js []
+                                     class)]
+    (when (pos? (.-length classes))
+      (.join classes " "))))
+
+(defn ^string class-names
+  ([])
+  ([class]
+   (cond
+     ;; {c1 true c2 false}
+     (map? class)
+     (class-names-map class)
+
+     ;; [c1 c2 c3]
+     (or (array? class) (coll? class))
+     (class-names-coll class)
+
+     ;; :c1
+     (keyword? class)
+     (-name ^not-native class)
+
+     :else class))
+  ([a b]
+   (if ^boolean a
+     (if ^boolean b
+       (str (class-names a) " " (class-names b))
+       (class-names a))
+     (class-names b)))
+  ([a b & rst]
+   (reduce class-names (class-names a b) rst)))
+
+(defn set-id-class
+  "Takes the id and class from tag keyword, and adds them to the
+  other props. Parsed tag is JS object with :id and :class properties."
+  [props id-class]
+  (let [id (aget id-class 1)
+        classes ^js/Array (aget id-class 2)]
+    (cond-> props
+            ;; Only use ID from tag keyword if no :id in props already
+            (and (some? id) (nil? (get props :id)))
+            (assoc :id id)
+
+            ;; Merge classes
+            (and (some? classes) (pos? (.-length classes)))
+            (assoc :class (class-names classes (get props :class))))))
+
+(defn convert-props [props id-class ^boolean shallow?]
+  (let [class (get props :class)
+        props (-> props
+                  (cond-> class (assoc :class (class-names class)))
+                  (set-id-class id-class))]
+    (cond
+      ^boolean (aget id-class 3)
+      (convert-custom-prop-value props)
+
+      shallow?
+      (convert-prop-value-shallow props)
+
+      :else (convert-prop-value props))))
+
+(defn interpret-attrs [attrs id-class shallow?]
+  (if (map? attrs)
+    (convert-props attrs id-class shallow?)
+    (do
+      (js/console.error "UIx: a map of DOM attributes is exppected, but got " attrs)
+      attrs)))

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -176,5 +176,5 @@
   (if (map? attrs)
     (convert-props attrs id-class shallow?)
     (do
-      (js/console.error "UIx: a map of DOM attributes is exppected, but got " attrs)
+      (prn "UIx: a map of element attributes is exppected, but got " attrs)
       attrs)))


### PR DESCRIPTION
This PR adds opt-in runtime interpretation for attributes in UTL DOM elements. We decided that it's a fair tradeoff to have given how convenient it is to be able to update attrs map at runtime, before it is passed into a DOM element.

Previously this would compile into `(react/createElement attrs 1 2 3)` which passes whatever `attrs` is as props object, Clojure map won't work here obviously.
```clojure
#el [:div attrs 1 2 3]
```

In this PR `attrs` will be wrapped into runtime interpretation call which will turn it into a JS object efficiently, otherwise, if `attrs` is not a map you'll the following error in the console: `UIx: a map of DOM attributes is exppected, but got attrs`. The error message can be improved later to point exactly where the problem is, in the source cljs code.

Additionally, since `:style` is the only nested map attribute on a DOM element, the compiler is able to address this case
```clojure
#el [:div {:titlte "string" :style x}]
```
The above will compile into `(react/createElement #js {:title "string" :style (interpret x)})`, which basically means that even though styles map is dynamic, the outer attrs map literal is still compiled into js object.