### PR TITLE
Make attrs/props optional

### DIFF
--- a/core/benchmark/uix/benchmark.cljs
+++ b/core/benchmark/uix/benchmark.cljs
@@ -3,38 +3,21 @@
   (:require [reagent.core :as r]
             ["react-dom/server" :as rserver]
             [react :as react]
-            [uix.compiler.alpha :as uixc]
-            [uix.core.alpha :refer [html]]
-            [uix.dom.alpha :as uix.dom]
             [uix.hiccup :as hiccup]
             [uix.react :refer [Editor]]))
 
-(defn reagent-interpret []
-  (r/as-element [hiccup/editor]))
-
-(defn uix-interpret []
-  (uixc/as-element [hiccup/editor]))
-
-(defn uix-compile []
-  (uixc/as-element [hiccup/editor-compiled]))
-
-
 (defn render [el]
-  (rserver/renderToString el))
+      (rserver/renderToString el))
 
-(do
+(def reagent-compiler
+  (r/create-compiler {:function-components true}))
 
-  (bench :react 10000 (render (react/createElement Editor)))
-  (bench :react 10000 (render (react/createElement Editor)))
+(js/console.log "Warming up...")
+(bench :react 10000 (render (react/createElement Editor)))
+(bench :uix-compiled 10000 (render #el [hiccup/editor-compiled]))
+(bench :reagent-interpret 10000 (render (r/as-element [hiccup/editor])))
 
-  (bench :uix-compile 10000 (render (uix-compile)))
-  (bench :uix-compile 10000 (render (uix-compile)))
-
-  (bench :uix-interpret 10000 (render (uix-interpret)))
-  (bench :uix-interpret 10000 (render (uix-interpret)))
-
-  (bench :reagent-interpret 10000 (render (reagent-interpret)))
-  (bench :reagent-interpret 10000 (render (reagent-interpret))))
-
-(uix.dom/render [uix-interpret] js/root)
-
+(js/console.log "Running the benchmark...")
+(bench :react 10000 (render (react/createElement Editor)))
+(bench :uix-compiled 10000 (render #el [hiccup/editor-compiled]))
+(bench :reagent-interpret 10000 (render (r/as-element [hiccup/editor] reagent-compiler)))

--- a/core/benchmark/uix/hiccup.cljs
+++ b/core/benchmark/uix/hiccup.cljs
@@ -1,5 +1,5 @@
 (ns uix.hiccup
-  (:require [uix.core.alpha :refer [html]]))
+  (:require [uix.core.alpha :refer [defui]]))
 
 (defn input-field [{:keys [field-type type placeholder size]
                     :or {field-type :input}}]
@@ -75,94 +75,87 @@
 
 ;; ==== Pre-compiled components ====
 
-(defn input-field-compiled
+(defui input-field-compiled
   [{:keys [field-type type placeholder size]
     :or {field-type :input}}]
   (if (= field-type :textarea)
-    (html
-      [:textarea
-       {:class ["form-control" (get {:large "form-control-lg"} size)]
-        :type type
-        :placeholder placeholder
-        :style {:border "1px solid blue"
-                :border-radius 3
-                :padding "4px 8px"}}])
-    (html
-      [:input
-       {:class ["form-control" (get {:large "form-control-lg"} size)]
-        :type type
-        :placeholder placeholder
-        :style {:border "1px solid blue"
-                :border-radius 3
-                :padding "4px 8px"}}])))
+    #el [:textarea
+         {:class ["form-control" (get {:large "form-control-lg"} size)]
+          :type type
+          :placeholder placeholder
+          :style {:border "1px solid blue"
+                  :border-radius 3
+                  :padding "4px 8px"}}]
+    #el [:input
+         {:class ["form-control" (get {:large "form-control-lg"} size)]
+          :type type
+          :placeholder placeholder
+          :style {:border "1px solid blue"
+                  :border-radius 3
+                  :padding "4px 8px"}}]))
 
-(defn button-compiled [{:keys [size kind class]} child]
-  (html
-    [:button.btn
-     {:class [(get {:large "btn-lg"} size)
-              (get {:primary "btn-primary"} kind)
-              class]
-      :style {:padding "8px 24px"
-              :color :white
-              :background :blue
-              :font-size "11px"
-              :text-transform :uppercase
-              :text-align :center}}
-     ^:inline child]))
+(defui button-compiled [{:keys [size kind class children]}]
+  #el [:button.btn
+       {:class [(get {:large "btn-lg"} size)
+                (get {:primary "btn-primary"} kind)
+                class]
+        :style {:padding "8px 24px"
+                :color :white
+                :background :blue
+                :font-size "11px"
+                :text-transform :uppercase
+                :text-align :center}}
+       children])
 
-(defn fieldset-compiled [& children]
-  (html
-    [:fieldset.form-group
-     {:style {:padding 8
-              :border :none}}
-     ^:inline children]))
+(defui fieldset-compiled [{:keys [children]}]
+  #el [:fieldset.form-group
+       {:style {:padding 8
+                :border :none}}
+       children])
 
-(defn form-compiled [& children]
-  (html
-    [:form ^:inline children]))
+(defui form-compiled [{:keys [children]}]
+  #el [:form children])
 
-(defn row-compiled [& children]
-  (html [:div.row ^:inline children]))
+(defui row-compiled [{:keys [children]}]
+  #el [:div.row children])
 
-(defn col-compiled [{:keys [md xs offset-md]} & children]
-  (html
-    [:div {:class [(str "col-md-" md)
-                   (str "col-xs-" xs)
-                   (str "offset-md-" offset-md)]}
-     ^:inline children]))
+(defui col-compiled [{:keys [md xs offset-md children]}]
+  #el [:div {:class [(str "col-md-" md)
+                     (str "col-xs-" xs)
+                     (str "offset-md-" offset-md)]}
+       children])
 
-(defn editor-compiled []
-  (html
-    [:div.editor-page
-     [:div.container.page
-      [row-compiled
-       [col-compiled
-        {:md 10
-         :xs 12
-         :offset-md 1}
-        [form-compiled
-         [:fieldset
-          [fieldset-compiled
-           [input-field-compiled
-            {:type "text"
-             :placeholder "Article Title"
-             :size :large}]]
-          [fieldset-compiled
-           [input-field-compiled
-            {:type "text"
-             :placeholder "What's this article about?"}]]
-          [fieldset-compiled
-           [input-field-compiled
-            {:rows "8"
-             :field-type :textarea
-             :placeholder "Write your article (in markdown)"}]]
-          [fieldset-compiled
-           [input-field-compiled
-            {:type "text"
-             :placeholder "Enter tags"}]
-           [:div.tag-list]]
-          [button-compiled
-           {:size :large
-            :kind :primary
-            :class "pull-xs-right"}
-           "Update Article"]]]]]]]))
+(defui editor-compiled []
+  #el [:div.editor-page
+       #el [:div.container.page
+            #el [row-compiled
+                 #el [col-compiled
+                      {:md 10
+                       :xs 12
+                       :offset-md 1}
+                      #el [form-compiled
+                           #el [:fieldset
+                                #el [fieldset-compiled
+                                     #el [input-field-compiled
+                                          {:type "text"
+                                           :placeholder "Article Title"
+                                           :size :large}]]
+                                #el [fieldset-compiled
+                                     #el [input-field-compiled
+                                          {:type "text"
+                                           :placeholder "What's this article about?"}]]
+                                #el [fieldset-compiled
+                                     #el [input-field-compiled
+                                          {:rows "8"
+                                           :field-type :textarea
+                                           :placeholder "Write your article (in markdown)"}]]
+                                #el [fieldset-compiled
+                                     #el [input-field-compiled
+                                          {:type "text"
+                                           :placeholder "Enter tags"}]
+                                     #el [:div.tag-list]]
+                                #el [button-compiled
+                                     {:size :large
+                                      :kind :primary
+                                      :class "pull-xs-right"}
+                                     "Update Article"]]]]]]])

--- a/core/deps.edn
+++ b/core/deps.edn
@@ -18,7 +18,7 @@
                        :main-opts ["-m" "figwheel.main" "--build" "dev" "--repl" "--serve"]}
            :rec-ssr  {:main-opts ["-m" "uix.recipes.server-rendering"]}
            :benchmark {:extra-paths ["benchmark"]
-                       :extra-deps {reagent/reagent {:mvn/version "0.9.0-SNAPSHOT"}
+                       :extra-deps {reagent/reagent {:mvn/version "1.1.0"}
                                     criterium/criterium {:mvn/version "0.4.5"}
                                     enlive/enlive {:mvn/version "1.1.6"}
                                     hiccup/hiccup {:mvn/version "1.0.5"}

--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -24,8 +24,12 @@
 (defn as-react [f]
   #(f (bean/bean %)))
 
-(defn component-element [component-type props children]
-  (let [js-props (if-some [key (:key props)]
+(defn component-element [component-type ^js props-children children]
+  (let [props (aget props-children 0)
+        js-props (if-some [key (:key props)]
                    #js {:key key :argv (dissoc props :key)}
-                   #js {:argv props})]
-    (.apply react/createElement nil (.concat #js [(debug/with-name component-type) js-props] children))))
+                   #js {:argv props})
+        args (if (= 2 (.-length props-children))
+               #js [(debug/with-name component-type) js-props (aget props-children 1)]
+               #js [(debug/with-name component-type) js-props])]
+    (.apply react/createElement nil (.concat args children))))

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -4,6 +4,51 @@
             [uix.compiler.js :as js]
             [uix.compiler.attributes :as attrs]))
 
+(defn- add-key [props meta]
+  (cond-> props
+          (:key meta) (assoc :key (:key meta))))
+
+(defmulti compile-attrs (fn [tag attrs opts] tag))
+
+(defmethod compile-attrs :element [_ attrs {:keys [meta tag id-class]}]
+  (let [attrs (add-key attrs meta)]
+    (if (map? attrs)
+      `(cljs.core/array
+         ~(cond-> attrs
+                  :always (attrs/set-id-class id-class)
+                  (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
+                  (and (some? (:style attrs))
+                       (not (map? (:style attrs))))
+                  (assoc :style `(uix.compiler.attributes/interpret-attrs ~(:style attrs) (cljs.core/array) true))
+                  :always (attrs/compile-attrs {:custom-element? (re-find #"-" tag)})
+                  :always js/to-js))
+      `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false))))
+
+(defmethod compile-attrs :component [_ props {:keys [meta]}]
+  `(uix.compiler.attributes/interpret-props ~(add-key props meta)))
+
+(defmethod compile-attrs :fragment [_ attrs {:keys [meta]}]
+  (let [attrs (add-key attrs meta)]
+    (if (map? attrs)
+      `(cljs.core/array ~(-> attrs attrs/compile-attrs js/to-js))
+      `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false))))
+
+(defmethod compile-attrs :suspense [_ attrs {:keys [meta]}]
+  (let [attrs (add-key attrs meta)]
+    (if (map? attrs)
+      `(cljs.core/array ~(-> attrs attrs/compile-attrs js/to-js))
+      `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false))))
+
+(defmethod compile-attrs :interop [_ props {:keys [meta]}]
+  (let [props (add-key props meta)]
+    (if (map? props)
+      `(cljs.core/array
+         ~(cond-> props
+                  (:ref props) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref props)))
+                  :always (attrs/compile-attrs {:custom-element? true})
+                  :always (js/to-js-map true)))
+      `(uix.compiler.attributes/interpret-attrs ~props (cljs.core/array) true))))
+
 ;; Compiles Hiccup into React.createElement
 (defmulti compile-element
   (fn [[tag]]
@@ -17,53 +62,30 @@
 
 (defmethod compile-element :element [v]
   (let [[tag attrs & children] v
-        id-class (attrs/parse-tag tag)
-        tag (first id-class)
-        m (meta v)
-        attrs (when (some? attrs)
-                (if-not (map? attrs)
-                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false)
-                  (cond-> attrs
-                    :always (attrs/set-id-class id-class)
-                    (:key m) (assoc :key (:key m))
-                    (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
-                    (and (some? (:style attrs))
-                         (not (map? (:style attrs))))
-                    (assoc :style `(uix.compiler.attributes/interpret-attrs ~(:style attrs) (cljs.core/array) true))
-                    :always (attrs/compile-attrs {:custom-element? (re-find #"-" tag)})
-                    :always js/to-js)))
-        ret `(>el ~tag ~attrs ~@children)]
+        tag-id-class (attrs/parse-tag tag)
+        tag-str (first tag-id-class)
+        attrs-children (compile-attrs :element attrs {:meta (meta v)
+                                                      :tag tag-str
+                                                      :tag-id-class tag-id-class})
+        ret `(>el ~tag-str ~attrs-children (cljs.core/array ~@children))]
     ret))
 
 (defmethod compile-element :component [v]
   (let [[tag props & children] v
-        tag (vary-meta tag assoc :tag 'js)]
-    `(uix.compiler.alpha/component-element ~tag ~props (cljs.core/array ~@children))))
+        tag (vary-meta tag assoc :tag 'js)
+        props-children (compile-attrs :component props {:meta (meta v)})]
+    `(uix.compiler.alpha/component-element ~tag ~props-children (cljs.core/array ~@children))))
 
 (defmethod compile-element :fragment [v]
   (let [[_ attrs & children] v
-        m (meta v)
-        attrs (when (some? attrs)
-                (if-not (map? attrs)
-                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
-                  (cond-> attrs
-                    (:key m) (assoc :key (:key m))
-                    :always attrs/compile-attrs
-                    :always js/to-js)))
-        ret `(>el fragment ~attrs ~@children)]
+        attrs (compile-attrs :fragment attrs {:meta (meta v)})
+        ret `(>el fragment ~attrs (cljs.core/array ~@children))]
     ret))
 
 (defmethod compile-element :suspense [v]
   (let [[_ attrs & children] v
-        m (meta v)
-        attrs (when (some? attrs)
-                (if-not (map? attrs)
-                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)
-                  (cond-> attrs
-                    (:key m) (assoc :key (:key m))
-                    :always attrs/compile-attrs
-                    :always js/to-js)))
-        ret `(>el suspense ~attrs ~children)]
+        attrs (compile-attrs :suspense attrs {:meta (meta v)})
+        ret `(>el suspense ~attrs (cljs.core/array ~@children))]
     ret))
 
 (defmethod compile-element :portal [v]
@@ -73,17 +95,9 @@
     `(~'js/ReactDOM.createPortal ~child ~node)))
 
 (defmethod compile-element :interop [v]
-  (let [[_ tag attrs & children] v
-        m (meta v)
-        attrs (when (some? attrs)
-                (if-not (map? attrs)
-                  `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) true)
-                  (cond-> attrs
-                    (:key m) (assoc :key (:key m))
-                    (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
-                    :always attrs/compile-attrs
-                    :always js/to-js)))]
-    `(>el ~tag ~attrs ~children)))
+  (let [[_ tag props & children] v
+        props (compile-attrs :interop props {:meta (meta v)})]
+    `(>el ~tag ~props (cljs.core/array ~@children))))
 
 (defn compile-html
   "Compiles Hiccup expr into React.js calls"

--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -4,6 +4,9 @@
             [uix.compiler.alpha :as r]
             [uix.compiler.attributes]))
 
-(def >el react/createElement)
+(defn >el [tag attrs-children children]
+  (let [args (-> #js [tag] (.concat attrs-children) (.concat children))]
+    (.apply react/createElement nil args)))
+
 (def suspense react/Suspense)
 (def fragment react/Fragment)

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -173,8 +173,11 @@
       :else (convert-prop-value props))))
 
 (defn interpret-attrs [attrs id-class shallow?]
-  (if (map? attrs)
-    (convert-props attrs id-class shallow?)
-    (do
-      (prn "UIx: a map of element attributes is exppected, but got " attrs)
-      attrs)))
+  (if (or (map? attrs) (nil? attrs))
+    #js [(convert-props attrs id-class shallow?)]
+    #js [nil attrs]))
+
+(defn interpret-props [props]
+  (if (or (map? props) (nil? props))
+    #js [props]
+    #js [nil props]))

--- a/core/src/uix/compiler/js.clj
+++ b/core/src/uix/compiler/js.clj
@@ -8,23 +8,22 @@
               (keyword? x) :keyword
               :else (class x))))
 
-(defn to-js-map [m]
+(defn to-js-map [m shallow?]
   (when (seq m)
-    (let [key-strs (mapv to-js (keys m))
-          non-str (remove string? key-strs)
-          _ (assert (empty? non-str)
-                    (str "UIx: Props can't be dynamic:"
-                         (pr-str non-str) "in: " (pr-str m)))
-          kvs-str (->> (mapv #(-> (str \' % "':~{}")) key-strs)
+    (let [kvs-str (->> (mapv to-js (keys m))
+                       (mapv #(-> (str \' % "':~{}")))
                        (interpose ",")
                        (apply str))]
       (vary-meta
-        (list* 'js* (str "{" kvs-str "}") (mapv to-js (vals m)))
+        (list* 'js* (str "{" kvs-str "}")
+               (if shallow?
+                 (vals m)
+                 (mapv to-js (vals m))))
         assoc :tag 'object))))
 
 (defmethod to-js :keyword [x] (name x))
 
-(defmethod to-js :map [m] (to-js-map m))
+(defmethod to-js :map [m] (to-js-map m false))
 
 (defmethod to-js :vector [xs]
   (apply list 'cljs.core/array (mapv to-js xs)))


### PR DESCRIPTION
This PR makes it possible to have an optional attrs/props map in elements and components.

Here are some examples
```clojure
#el [:div]
#el [:div {} 1 2 3]
#el [:div x 1 2 3] ;; x can be both runtime attrs or a child element
#el [:div 1 2 3]
#el [:div nil 1 2 3] ;; nil will be treated as attrs
```
^ same applies to components

Additionally the PR updates React vs Reagent vs UIx benchmark. The benchmark compares latest version of Reagent, with functional components enabled by default, to plain React and compiled UIx. Those are the results
```
react x 74074 ops/s, elapsed 135ms
benchmark.js:626 uix-compiled x 46083 ops/s, elapsed 217ms
benchmark.js:626 reagent-interpret x 23310 ops/s, elapsed 429ms
```

- UIx is 0.6x slower than React
- Reagent is 3.2x slower than React and 2x slower than UIx