### PR TITLE
move component debugging code and improve performance

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -2,7 +2,8 @@
   "Hiccup and UIx components interpreter. Based on Reagent."
   (:require [react :as react]
             [uix.hooks.alpha :as hooks]
-            [cljs-bean.core :as bean]))
+            [cljs-bean.core :as bean]
+            [uix.compiler.debug :as debug]))
 
 (def ^:dynamic *default-compare-args* #(= (.-argv %1) (.-argv %2)))
 

--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -2,8 +2,7 @@
   "Hiccup and UIx components interpreter. Based on Reagent."
   (:require [react :as react]
             [uix.hooks.alpha :as hooks]
-            [cljs-bean.core :as bean]
-            [uix.compiler.debug :as debug]))
+            [cljs-bean.core :as bean]))
 
 (def ^:dynamic *default-compare-args* #(= (.-argv %1) (.-argv %2)))
 
@@ -30,6 +29,6 @@
                    #js {:key key :argv (dissoc props :key)}
                    #js {:argv props})
         args (if (= 2 (.-length props-children))
-               #js [(debug/with-name component-type) js-props (aget props-children 1)]
-               #js [(debug/with-name component-type) js-props])]
+               #js [component-type js-props (aget props-children 1)]
+               #js [component-type js-props])]
     (.apply react/createElement nil (.concat args children))))

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -5,26 +5,29 @@
             [uix.compiler.attributes :as attrs]))
 
 (defn- add-key [props meta]
-  (cond-> props
-          (:key meta) (assoc :key (:key meta))))
+  (if (or (map? props) (nil? props))
+    (cond-> props
+            (:key meta) (assoc :key (:key meta)))
+    props))
 
 (defmulti compile-attrs (fn [tag attrs opts] tag))
 
-(defmethod compile-attrs :element [_ attrs {:keys [meta tag id-class]}]
-  (let [attrs (add-key attrs meta)]
+(defmethod compile-attrs :element [_ attrs {:keys [meta tag-id-class]}]
+  (let [attrs (-> attrs
+                  (add-key meta)
+                  (attrs/set-id-class tag-id-class))]
     (cond
       (nil? attrs) `(cljs.core/array)
       (map? attrs)
       `(cljs.core/array
          ~(cond-> attrs
-                  :always (attrs/set-id-class id-class)
                   (:ref attrs) (assoc :ref `(uix.compiler.alpha/unwrap-ref ~(:ref attrs)))
                   (and (some? (:style attrs))
                        (not (map? (:style attrs))))
                   (assoc :style `(uix.compiler.attributes/convert-props ~(:style attrs) (cljs.core/array) true))
-                  :always (attrs/compile-attrs {:custom-element? (re-find #"-" tag)})
+                  :always (attrs/compile-attrs {:custom-element? (last tag-id-class)})
                   :always js/to-js))
-      :else `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false))))
+      :else `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@tag-id-class) false))))
 
 (defmethod compile-attrs :component [_ props {:keys [meta]}]
   `(uix.compiler.attributes/interpret-props ~(add-key props meta)))
@@ -65,11 +68,9 @@
 (defmethod compile-element :element [v]
   (let [[tag attrs & children] v
         tag-id-class (attrs/parse-tag tag)
-        tag-str (first tag-id-class)
         attrs-children (compile-attrs :element attrs {:meta (meta v)
-                                                      :tag tag-str
                                                       :tag-id-class tag-id-class})
-        ret `(>el ~tag-str ~attrs-children (cljs.core/array ~@children))]
+        ret `(>el ~(first tag-id-class) ~attrs-children (cljs.core/array ~@children))]
     ret))
 
 (defmethod compile-element :component [v]

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -12,7 +12,9 @@
 
 (defmethod compile-attrs :element [_ attrs {:keys [meta tag id-class]}]
   (let [attrs (add-key attrs meta)]
-    (if (map? attrs)
+    (cond
+      (nil? attrs) `(cljs.core/array)
+      (map? attrs)
       `(cljs.core/array
          ~(cond-> attrs
                   :always (attrs/set-id-class id-class)
@@ -22,7 +24,7 @@
                   (assoc :style `(uix.compiler.attributes/convert-props ~(:style attrs) (cljs.core/array) true))
                   :always (attrs/compile-attrs {:custom-element? (re-find #"-" tag)})
                   :always js/to-js))
-      `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false))))
+      :else `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@id-class) false))))
 
 (defmethod compile-attrs :component [_ props {:keys [meta]}]
   `(uix.compiler.attributes/interpret-props ~(add-key props meta)))

--- a/core/src/uix/compiler/attributes.clj
+++ b/core/src/uix/compiler/attributes.clj
@@ -30,19 +30,21 @@
   (let [[tag id class-name] (->> hiccup-tag name (re-matches re-tag) next)
         class-name (when-not (nil? class-name)
                      (str/replace class-name #"\." " "))]
-    (list tag id class-name)))
+    (list tag id class-name (some? (re-find #"-" tag)))))
 
 (defn set-id-class
   "Takes attributes map and parsed tag, and returns attributes merged with class names and id"
   [props [_ id class]]
-  (cond-> props
-          ;; Only use ID from tag keyword if no :id in props already
-          (and (some? id) (nil? (get props :id)))
-          (assoc :id id)
+  (if (or (map? props) (nil? props))
+    (cond-> props
+            ;; Only use ID from tag keyword if no :id in props already
+            (and (some? id) (nil? (get props :id)))
+            (assoc :id id)
 
-          ;; Merge classes
-          class
-          (assoc :class (join-classes [class (get props :class)]))))
+            ;; Merge classes
+            class
+            (assoc :class (join-classes [class (get props :class)])))
+    props))
 
 (defn camel-case
   "Turns kebab-case keyword into camel-case keyword"

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -184,10 +184,10 @@
 
   - [attrs] when `attrs` is actually a map of attributes
   - [nil attrs] when `attrs` is not a map, thus a child element"
-  [attrs id-class shallow?]
-  (if (or (map? attrs) (nil? attrs))
-    #js [(convert-props attrs id-class shallow?)]
-    #js [nil attrs]))
+  [maybe-attrs id-class shallow?]
+  (if (or (map? maybe-attrs) (nil? maybe-attrs))
+    #js [(convert-props maybe-attrs id-class shallow?)]
+    #js [(convert-props {} id-class shallow?) maybe-attrs]))
 
 (defn interpret-props
   "Returns a tuple of component props and a child element

--- a/core/src/uix/compiler/debug.cljs
+++ b/core/src/uix/compiler/debug.cljs
@@ -32,5 +32,4 @@
 (defn with-name [^js f]
   (when-let [component-name (effective-component-name f)]
     (when-some [display-name (format-display-name component-name)]
-      (set! (.-displayName f) display-name)))
-  f)
+      (set! (.-displayName f) display-name))))

--- a/core/src/uix/compiler/js.clj
+++ b/core/src/uix/compiler/js.clj
@@ -9,17 +9,19 @@
               :else (class x))))
 
 (defn to-js-map [m shallow?]
-  (when (seq m)
-    (let [kvs-str (->> (mapv to-js (keys m))
-                       (mapv #(-> (str \' % "':~{}")))
-                       (interpose ",")
-                       (apply str))]
-      (vary-meta
-        (list* 'js* (str "{" kvs-str "}")
-               (if shallow?
-                 (vals m)
-                 (mapv to-js (vals m))))
-        assoc :tag 'object))))
+  (cond
+    (nil? m) nil
+    (empty? m) `(cljs.core/js-obj)
+    :else (let [kvs-str (->> (mapv to-js (keys m))
+                             (mapv #(-> (str \' % "':~{}")))
+                             (interpose ",")
+                             (apply str))]
+            (vary-meta
+              (list* 'js* (str "{" kvs-str "}")
+                     (if shallow?
+                       (vals m)
+                       (mapv to-js (vals m))))
+              assoc :tag 'object))))
 
 (defmethod to-js :keyword [x] (name x))
 

--- a/core/src/uix/core/alpha.cljc
+++ b/core/src/uix/core/alpha.cljc
@@ -241,8 +241,7 @@
              (.-children props) (assoc :children (.-children props)))))
 
 #?(:cljs
-   (defn- with-name [f]
-     (debug/with-name f)))
+   (def with-name debug/with-name))
 
 #?(:clj
    (defmacro defui

--- a/core/src/uix/core/alpha.cljc
+++ b/core/src/uix/core/alpha.cljc
@@ -5,6 +5,7 @@
   (:require #?@(:cljs [[react :as r]
                        [uix.compiler.debug :as debug]])
             [uix.compiler.alpha :as compiler]
+            [uix.compiler.aot]
             [uix.lib :refer [doseq-loop]]
             [uix.hooks.alpha :as hooks]))
 
@@ -12,11 +13,11 @@
 ;; React's top-level API
 
 (defn strict-mode [child]
-  #?(:cljs [:> r/StrictMode child]
+  #?(:cljs #el [:> r/StrictMode child]
      :clj child))
 
 (defn profiler [child {:keys [id on-render] :as attrs}]
-  #?(:cljs [:> r/Profiler attrs child]
+  #?(:cljs #el [:> r/Profiler attrs child]
      :clj child))
 
 #?(:cljs

--- a/core/src/uix/core/alpha.cljc
+++ b/core/src/uix/core/alpha.cljc
@@ -5,7 +5,6 @@
   (:require #?@(:cljs [[react :as r]
                        [uix.compiler.debug :as debug]])
             [uix.compiler.alpha :as compiler]
-            [uix.compiler.aot :as uixr]
             [uix.lib :refer [doseq-loop]]
             [uix.hooks.alpha :as hooks]))
 

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -5,9 +5,9 @@
 
 (deftest test-parse-tag
   (is (= (attrs/parse-tag (name :div#id.class))
-         ["div" "id" "class"]))
+         ["div" "id" "class" false]))
   (is (= (attrs/parse-tag (name :custom-tag))
-         ["custom-tag" nil nil])))
+         ["custom-tag" nil nil true])))
 
 (deftest test-class-names
   (is (= (attrs/compile-config-kv :class nil) nil))

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -33,8 +33,8 @@
 
 (deftest test-compile-html
   (is (= (aot/compile-html [:h1])
-         '(uix.compiler.aot/>el "h1" nil)))
+         '(uix.compiler.aot/>el "h1" (cljs.core/array) (cljs.core/array))))
   (is (= (aot/compile-html '[:> x {} 1 2])
-         '(uix.compiler.aot/>el x nil [1 2])))
+         '(uix.compiler.aot/>el x (cljs.core/array (cljs.core/js-obj)) (cljs.core/array 1 2))))
   (is (= (aot/compile-html '[:> x {:x 1 :ref 2} 1 2])
-         '(uix.compiler.aot/>el x (js* "{'x':~{},'ref':~{}}" 1 (uix.compiler.alpha/unwrap-ref 2)) [1 2]))))
+         '(uix.compiler.aot/>el x (cljs.core/array (js* "{'x':~{},'ref':~{}}" 1 (uix.compiler.alpha/unwrap-ref 2))) (cljs.core/array 1 2)))))

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -3,7 +3,8 @@
             [uix.compiler.alpha :as uixc]
             [uix.test-utils :refer [as-string js-equal? with-error symbol-for]]
             [uix.compiler.debug :as debug]
-            [uix.core.alpha :as uix.core]))
+            [uix.core.alpha :as uix.core]
+            [uix.dom.alpha :as uix.dom]))
 
 (enable-console-print!)
 
@@ -171,7 +172,7 @@
 
 (deftest test-portal
   (try
-    #el [:-> 1 2]
+    (uix.dom/create-portal 1 2)
     (catch :default e
       (is "Target container is not a DOM element." (.-message e)))))
 

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -12,10 +12,10 @@
 
 (uix.core/defui test-seq-return-comp []
   (for [x (range 2)]
-    [:span {} x]))
+    #el [:span {} x]))
 
 (deftest test-seq-return
-  (is (= (as-string (uix.core/html [test-seq-return-comp])) "<span>0</span><span>1</span>")))
+  (is (= (as-string #el [test-seq-return-comp]) "<span>0</span><span>1</span>")))
 
 (when ^boolean goog.DEBUG
   (deftest test-default-format-display-name
@@ -39,134 +39,131 @@
 
 
 (uix.core/defui to-string-test-comp [props]
-  [:div {} (str "i am " (:foo props))])
+  #el [:div {} (str "i am " (:foo props))])
 
 (deftest to-string-test []
   (is (re-find #"i am foobar"
-               (as-string (uix.core/html [to-string-test-comp {:foo "foobar"}])))))
+               (as-string #el [to-string-test-comp {:foo "foobar"}]))))
 
 (deftest data-aria-test []
   (is (re-find #"data-foo"
-               (as-string (uix.core/html [:div {:data-foo "x"}]))))
+               (as-string #el [:div {:data-foo "x"}])))
   (is (re-find #"aria-labelledby"
-               (as-string (uix.core/html [:div {:aria-labelledby "x"}]))))
+               (as-string #el [:div {:aria-labelledby "x"}])))
   (is (re-find #"enc[tT]ype"
-               (as-string (uix.core/html [:div {"encType" "x"}])))
+               (as-string #el [:div {"encType" "x"}]))
       "Strings are passed through to React, and have to be camelcase.")
   (is (re-find #"enc[tT]ype"
-               (as-string (uix.core/html [:div {:enc-type "x"}])))
+               (as-string #el [:div {:enc-type "x"}]))
       "Strings are passed through to React, and have to be camelcase."))
 
 (deftest dynamic-id-class []
   (is (re-find #"id=.foo"
-               (as-string (uix.core/html [:div#foo {:class "bar"}]))))
+               (as-string #el [:div#foo {:class "bar"}])))
   (is (re-find #"class=.foo bar"
-               (as-string (uix.core/html [:div.foo {:class "bar"}]))))
+               (as-string #el [:div.foo {:class "bar"}])))
   (is (re-find #"class=.foo bar"
-               (as-string (uix.core/html [:div.foo.bar]))))
+               (as-string #el [:div.foo.bar])))
   (is (re-find #"id=.foo"
-               (as-string (uix.core/html [:div#foo.foo.bar]))))
+               (as-string #el [:div#foo.foo.bar])))
   (is (re-find #"class=.xxx bar"
-               (as-string (uix.core/html [:div#foo.xxx.bar]))))
+               (as-string #el [:div#foo.xxx.bar])))
   (is (re-find #"id=.foo"
-               (as-string (uix.core/html [:div.bar {:id "foo"}]))))
+               (as-string #el [:div.bar {:id "foo"}])))
   (is (re-find #"id=.foo"
-               (as-string (uix.core/html [:div.bar.xxx {:id "foo"}]))))
+               (as-string #el [:div.bar.xxx {:id "foo"}])))
   (is (re-find #"id=.foo"
-               (as-string (uix.core/html [:div#bar {:id "foo"}])))
+               (as-string #el [:div#bar {:id "foo"}]))
       "Attributes id overwrites tag id"))
 
 (uix.core/defui null-comp [do-show]
   (when do-show
-    [:div {} "div in test-null-component"]))
+    #el [:div {} "div in test-null-component"]))
 
 (deftest test-null-component
   (is (not (re-find #"test-null-component"
-                    (as-string (uix.core/html [null-comp false])))))
+                    (as-string #el [null-comp false]))))
   (is (re-find #"test-null-component"
-               (as-string (uix.core/html [null-comp true])))))
+               (as-string #el [null-comp true]))))
 
 
 (deftest test-class-from-collection
-  (is (= (as-string (uix.core/html [:p {:class ["a" "b" "c" "d"]}]))
-         (as-string (uix.core/html [:p {:class "a b c d"}]))))
-  #_(is (= (as-string (uix.core/html [:p {:class ["a" nil "b" false "c" nil]}]))
-           (as-string (uix.core/html [:p {:class "a b c"}]))))
-  (is (= (as-string (uix.core/html [:p {:class #{"a" "b" "c"}}]))
-         (as-string (uix.core/html [:p {:class "a b c"}])))))
+  (is (= (as-string #el [:p {:class ["a" "b" "c" "d"]}])
+         (as-string #el [:p {:class "a b c d"}])))
+  #_(is (= (as-string #el [:p {:class ["a" nil "b" false "c" nil]}])
+           (as-string #el [:p {:class "a b c"}])))
+  (is (= (as-string #el [:p {:class #{"a" "b" "c"}}])
+         (as-string #el [:p {:class "a b c"}]))))
 
 (uix.core/defui key-tester []
-  [:div {}
-   (for [i (range 3)]
-     ^{:key i} [:p i])
-   (for [i (range 3)]
-     [:p {:key i} i])])
+  #el [:div {}
+       (for [i (range 3)]
+         ^{:key i} #el [:p i])
+       (for [i (range 3)]
+         #el [:p {:key i} i])])
 
 (deftest test-keys
-  (with-error #(as-string (uix.core/html [key-tester]))))
+  (with-error #(as-string #el [key-tester])))
 
 
 (deftest style-property-names-are-camel-cased
   (is (re-find #"<div style=\"text-align:center(;?)\">foo</div>"
-               (as-string (uix.core/html [:div {:style {:text-align "center"}} "foo"])))))
+               (as-string #el [:div {:style {:text-align "center"}} "foo"]))))
 
 (deftest custom-element-class-prop
   (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
-               (as-string (uix.core/html [:custom-element {:class "foobar"} "foo"]))))
+               (as-string #el [:custom-element {:class "foobar"} "foo"])))
 
   (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
-               (as-string (uix.core/html [:custom-element.foobar "foo"])))))
+               (as-string #el [:custom-element.foobar "foo"]))))
 
 (deftest test-fragments
   #_(testing "Fragment as array"
       (uix.core/defui comp1 []
-        #js [(uix.core/html [:div {} "hello"])
-             (uix.core/html [:div {} "world"])])
+        #js [#el [:div {} "hello"]
+             #el [:div {} "world"]])
       (is (= "<div>hello</div><div>world</div>"
-             (as-string (uix.core/html [comp])))))
+             (as-string #el [comp]))))
 
   (testing "Fragment element, :<>"
     (uix.core/defui comp2 []
-      [:<> {}
-       [:div {} "hello"]
-       [:div {} "world"]
-       [:div {} "foo"]])
+      #el [:<> {}
+           #el [:div {} "hello"]
+           #el [:div {} "world"]
+           #el [:div {} "foo"]])
     (is (= "<div>hello</div><div>world</div><div>foo</div>"
-           (as-string (uix.core/html [comp2])))))
+           (as-string #el [comp2]))))
 
   (testing "Fragment key"
     ;; This would cause React warning if both fragments didn't have key set
     ;; But wont fail the test
     (uix.core/defui comp4 []
-      [:<> {}
-       [:div {} "foo"]])
+      #el [:<> {}
+           #el [:div {} "foo"]])
     (uix.core/defui comp3 []
-      [:div {}
-       (list
-         (uix.core/html
-           [:<> {:key 1}
-            [:div {} "hello"]
-            [:div {} "world"]])
-         (uix.core/html
-           [comp4 {:key 2}])
-         (uix.core/html
-           ^{:key 3}
-           [:<> {}
-            [:div {} "1"]
-            [:div {} "2"]]))])
+      #el [:div {}
+           (list
+             #el [:<> {:key 1}
+                  #el [:div {} "hello"]
+                  #el [:div {} "world"]]
+             #el [comp4 {:key 2}]
+             ^{:key 3}
+             #el [:<> {}
+                  #el [:div {} "1"]
+                  #el [:div {} "2"]])])
     (is (= "<div><div>hello</div><div>world</div><div>foo</div><div>1</div><div>2</div></div>"
-           (as-string (uix.core/html [comp3]))))))
+           (as-string #el [comp3])))))
 
 (deftest test-suspense
-  (is (.-type (uix.core/html [:# {:fallback 1} 2]))
+  (is (.-type #el [:# {:fallback 1} 2])
       (symbol-for "react.suspense")))
 
 (deftest test-interop
   (testing "Interop element type"
-    (is (.-type (uix.core/html [:> inc]))
+    (is (.-type #el [:> inc])
         inc))
   (testing "Shallowly converted props"
-    (let [el (uix.core/html [:> inc {:a 1 :b {:c 2}} :child])
+    (let [el #el [:> inc {:a 1 :b {:c 2}} :child]
           props (.-props el)]
       (is (.-a props) 1)
       (is (.-b props) {:c 2})
@@ -174,7 +171,7 @@
 
 (deftest test-portal
   (try
-    (uix.core/html [:-> 1 2])
+    #el [:-> 1 2]
     (catch :default e
       (is "Target container is not a DOM element." (.-message e)))))
 
@@ -182,7 +179,7 @@
     (uix.core/defui test-c [props]
       (is (map? props) true)
       (is "TEXT" (:text props))
-      [:h1 (:text props)])
+      #el [:h1 (:text props)])
     (let [h1 (uixc/as-react test-c)
           el (h1 #js {:text "TEXT"})
           props (.-props el)]

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -116,7 +116,7 @@
                (as-string #el [:custom-element {:class "foobar"} "foo"])))
 
   (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
-               (as-string #el [:custom-element.foobar "foo"]))))
+               (as-string #el [:custom-element.foobar {} "foo"]))))
 
 (deftest test-fragments
   #_(testing "Fragment as array"

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -1,12 +1,11 @@
 (ns uix.core-test
   (:require [clojure.test :refer [deftest is async testing run-tests]]
-            [uix.core.alpha :as uix.core :refer [html defui defcontext]]
+            [uix.core.alpha :as uix.core :refer [defui defcontext]]
             ;[uix.core.lazy-loader :refer [require-lazy]]
             [uix.lib]
             [react :as r]
             [uix.test-utils :as t]
-            [cljs-bean.core :as bean]
-            [clojure.string :as str]))
+            [cljs-bean.core :as bean]))
 
 (deftest test-lib
   (is (= (seq (uix.lib/re-seq* (re-pattern "foo") "foo bar foo baz foo zot"))
@@ -17,9 +16,6 @@
 
   (is (= '("") (seq (uix.lib/re-seq* #"\s*" "")))))
 
-(deftest test-strict-mode
-  (is (= (uix.core/strict-mode 1) [:> r/StrictMode 1])))
-
 (deftest test-create-ref
   (let [ref (uix.core/create-ref 1)]
     (is (= (type ref) uix.core/ReactRef))
@@ -28,22 +24,22 @@
 (deftest test-memoize
   (uix.core/defui test-memoize-comp [{:keys [x]}]
     (is (= 1 x))
-    [:h1 x])
+    #el [:h1 x])
   (let [f (uix.core/memoize test-memoize-comp)]
     (is (t/react-element-of-type? f "react.memo"))
-    (is (= "<h1>1</h1>" (t/as-string (uix.core/html [f {:x 1}]))))))
+    (is (= "<h1>1</h1>" (t/as-string #el [f {:x 1}])))))
 
 #_(deftest test-require-lazy
     (require-lazy '[uix.core.alpha :refer [strict-mode]])
     (is (t/react-element-of-type? strict-mode "react.lazy")))
 
 (deftest test-html
-  (is (t/react-element-of-type? (html [:h1 1]) "react.element")))
+  (is (t/react-element-of-type? #el [:h1 1] "react.element")))
 
 (deftest test-defui
   (defui h1 [{:keys [children]}]
-    [:h1 {} children])
-  (is (= (t/as-string (uix.core/html [h1 {} 1])) "<h1>1</h1>")))
+    #el [:h1 {} children])
+  (is (= (t/as-string #el [h1 {} 1])) "<h1>1</h1>"))
 
 (deftest test-as-react
   (let [ctor (fn [props]

--- a/core/test/uix/hooks_test.cljs
+++ b/core/test/uix/hooks_test.cljs
@@ -9,61 +9,61 @@
   (is (= (maybe-js-deps nil) js/undefined)))
 
 (deftest test-state-hook
-  (let [f-state (fn [done]
-                  (let [state (core/state 1)]
-                    (is (instance? hooks/StateHook state))
-                    (is (or (== @state 1) (== @state 2)))
-                    (if (== @state 2)
-                      (done)
-                      (swap! state inc))))]
-    (async done
-      (t/render [f-state done]))))
+  (core/defui test-state-hook-comp [{:keys [done]}]
+    (let [state (core/state 1)]
+      (is (instance? hooks/StateHook state))
+      (is (or (== @state 1) (== @state 2)))
+      (if (== @state 2)
+        (done)
+        (swap! state inc))))
+  (async done
+    (t/render #el [test-state-hook-comp {:done done}])))
 
 (deftest test-cursor-in-hook
-  (let [f-state (fn [done]
-                  (let [state (core/state {:x 1})
-                        x (core/cursor-in state [:x])]
-                    (is (instance? hooks/Cursor x))
-                    (is (or (== @x 1) (== @x 2)))
-                    (if (== @x 2)
-                      (done)
-                      (swap! x inc))))]
-    (async done
-      (t/render [f-state done]))))
+  (core/defui test-cursor-in-hook-comp [{:keys [done]}]
+    (let [state (core/state {:x 1})
+          x (core/cursor-in state [:x])]
+      (is (instance? hooks/Cursor x))
+      (is (or (== @x 1) (== @x 2)))
+      (if (== @x 2)
+        (done)
+        (swap! x inc))))
+  (async done
+    (t/render #el [test-cursor-in-hook-comp {:done done}])))
 
 (deftest test-state-hook-identity
-  (let [f-state (fn [done]
-                  (let [xs (core/state [])]
-                    (if (< (count @xs) 2)
-                      (swap! xs conj xs)
-                      (let [[s1 s2] @xs]
-                        (is (identical? s1 s2))
-                        (done)))))]
-    (async done
-      (t/render [f-state done]))))
+  (core/defui test-state-hook-identity-comp [{:keys [done]}]
+    (let [xs (core/state [])]
+      (if (< (count @xs) 2)
+        (swap! xs conj xs)
+        (let [[s1 s2] @xs]
+          (is (identical? s1 s2))
+          (done)))))
+  (async done
+    (t/render #el [test-state-hook-identity-comp {:done done}])))
 
 (deftest test-ref-hook-mutable
-  (let [f-ref (fn [done]
-                (let [ref (core/ref 1)]
-                  (is (instance? hooks/RefHook ref))
-                  (is (== @ref 1))
-                  (swap! ref inc)
-                  (is (== @ref 2))
-                  (done)))]
-    (async done
-      (t/render [f-ref done]))))
+  (core/defui test-ref-hook-mutable-comp [{:keys [done]}]
+    (let [ref (core/ref 1)]
+      (is (instance? hooks/RefHook ref))
+      (is (== @ref 1))
+      (swap! ref inc)
+      (is (== @ref 2))
+      (done)))
+  (async done
+    (t/render #el [test-ref-hook-mutable-comp {:done done}])))
 
 (deftest test-ref-hook-memoized-instance
-  (let [f-ref (fn [done]
-                (let [ref (core/ref 1)
-                      refs (core/state [])]
-                  (if (< (count @refs) 2)
-                    (swap! refs conj ref)
-                    (let [[r1 r2] @refs]
-                      (is (identical? r1 r2))
-                      (done)))))]
-    (async done
-      (t/render [f-ref done]))))
+  (core/defui test-ref-hook-memoized-instance-comp [{:keys [done]}]
+    (let [ref (core/ref 1)
+          refs (core/state [])]
+      (if (< (count @refs) 2)
+        (swap! refs conj ref)
+        (let [[r1 r2] @refs]
+          (is (identical? r1 r2))
+          (done)))))
+  (async done
+    (t/render #el [test-ref-hook-memoized-instance-comp {:done done}])))
 
 #_(deftest test-effect-hook
     (let [f-effect (fn [done]


### PR DESCRIPTION
I've noticed that the code made for debugging (assigning formatted `displayName`) was running on every render, which is happening by accident after interpretation code was removed. This PR fixes the issue which also further improves UIx performance

UIx is now only 20% (vs 60% on current master) slower than React and 3.2x faster than Reagent