### PR TITLE
remove assigning :key via meta

### DIFF
--- a/core/dev/uix/recipes.cljc
+++ b/core/dev/uix/recipes.cljc
@@ -29,8 +29,7 @@
       [:select {:value @current-recipe*
                 :on-change #(reset! current-recipe* (keyword (.. % -target -value)))}
        (for [[k v] recipes]
-         ^{:key k}
-         [:option {:value k}
+         [:option {:key k :value k}
           (name k)])]]
      (when-let [recipe (get recipes @current-recipe*)]
        [:div

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -4,18 +4,10 @@
             [uix.compiler.js :as js]
             [uix.compiler.attributes :as attrs]))
 
-(defn- add-key [props meta]
-  (if (or (map? props) (nil? props))
-    (cond-> props
-            (:key meta) (assoc :key (:key meta)))
-    props))
-
 (defmulti compile-attrs (fn [tag attrs opts] tag))
 
-(defmethod compile-attrs :element [_ attrs {:keys [meta tag-id-class]}]
-  (let [attrs (-> attrs
-                  (add-key meta)
-                  (attrs/set-id-class tag-id-class))]
+(defmethod compile-attrs :element [_ attrs {:keys [tag-id-class]}]
+  (let [attrs (attrs/set-id-class attrs tag-id-class)]
     (cond
       (nil? attrs) `(cljs.core/array)
       (map? attrs)
@@ -28,29 +20,26 @@
                   :always js/to-js))
       :else `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array ~@tag-id-class) false))))
 
-(defmethod compile-attrs :component [_ props {:keys [meta]}]
-  `(uix.compiler.attributes/interpret-props ~(add-key props meta)))
+(defmethod compile-attrs :component [_ props _]
+  `(uix.compiler.attributes/interpret-props ~props))
 
-(defmethod compile-attrs :fragment [_ attrs {:keys [meta]}]
-  (let [attrs (add-key attrs meta)]
-    (if (map? attrs)
-      `(cljs.core/array ~(-> attrs attrs/compile-attrs js/to-js))
-      `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false))))
+(defmethod compile-attrs :fragment [_ attrs _]
+  (if (map? attrs)
+    `(cljs.core/array ~(-> attrs attrs/compile-attrs js/to-js))
+    `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)))
 
-(defmethod compile-attrs :suspense [_ attrs {:keys [meta]}]
-  (let [attrs (add-key attrs meta)]
-    (if (map? attrs)
-      `(cljs.core/array ~(-> attrs attrs/compile-attrs js/to-js))
-      `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false))))
+(defmethod compile-attrs :suspense [_ attrs _]
+  (if (map? attrs)
+    `(cljs.core/array ~(-> attrs attrs/compile-attrs js/to-js))
+    `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)))
 
-(defmethod compile-attrs :interop [_ props {:keys [meta]}]
-  (let [props (add-key props meta)]
-    (if (map? props)
-      `(cljs.core/array
-         ~(cond-> props
-                  :always (attrs/compile-attrs {:custom-element? true})
-                  :always (js/to-js-map true)))
-      `(uix.compiler.attributes/interpret-attrs ~props (cljs.core/array) true))))
+(defmethod compile-attrs :interop [_ props _]
+  (if (map? props)
+    `(cljs.core/array
+       ~(cond-> props
+                :always (attrs/compile-attrs {:custom-element? true})
+                :always (js/to-js-map true)))
+    `(uix.compiler.attributes/interpret-attrs ~props (cljs.core/array) true)))
 
 ;; Compiles Hiccup into React.createElement
 (defmulti compile-element
@@ -66,26 +55,25 @@
 (defmethod compile-element :element [v]
   (let [[tag attrs & children] v
         tag-id-class (attrs/parse-tag tag)
-        attrs-children (compile-attrs :element attrs {:meta (meta v)
-                                                      :tag-id-class tag-id-class})
+        attrs-children (compile-attrs :element attrs {:tag-id-class tag-id-class})
         ret `(>el ~(first tag-id-class) ~attrs-children (cljs.core/array ~@children))]
     ret))
 
 (defmethod compile-element :component [v]
   (let [[tag props & children] v
         tag (vary-meta tag assoc :tag 'js)
-        props-children (compile-attrs :component props {:meta (meta v)})]
+        props-children (compile-attrs :component props nil)]
     `(uix.compiler.alpha/component-element ~tag ~props-children (cljs.core/array ~@children))))
 
 (defmethod compile-element :fragment [v]
   (let [[_ attrs & children] v
-        attrs (compile-attrs :fragment attrs {:meta (meta v)})
+        attrs (compile-attrs :fragment attrs nil)
         ret `(>el fragment ~attrs (cljs.core/array ~@children))]
     ret))
 
 (defmethod compile-element :suspense [v]
   (let [[_ attrs & children] v
-        attrs (compile-attrs :suspense attrs {:meta (meta v)})
+        attrs (compile-attrs :suspense attrs nil)
         ret `(>el suspense ~attrs (cljs.core/array ~@children))]
     ret))
 
@@ -97,7 +85,7 @@
 
 (defmethod compile-element :interop [v]
   (let [[_ tag props & children] v
-        props (compile-attrs :interop props {:meta (meta v)})]
+        props (compile-attrs :interop props nil)]
     `(>el ~tag ~props (cljs.core/array ~@children))))
 
 (defn compile-html

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -146,8 +146,7 @@
                   #el [:div {} "hello"]
                   #el [:div {} "world"]]
              #el [comp4 {:key 2}]
-             ^{:key 3}
-             #el [:<> {}
+             #el [:<> {:key 3}
                   #el [:div {} "1"]
                   #el [:div {} "2"]])])
     (is (= "<div><div>hello</div><div>world</div><div>foo</div><div>1</div><div>2</div></div>"


### PR DESCRIPTION
This PR removes support for `key` attr assigning via metadata (`^{:key x}`)