### PR TITLE
No collection of class names

### DIFF
--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -13,7 +13,9 @@
   (is (= (attrs/compile-config-kv :class nil) nil))
   (testing "Named types"
     (is (= (attrs/compile-config-kv :class "a") "a"))
+    #_
     (is (= (attrs/compile-config-kv :class :a) :a)))
+  #_
   (testing "Collection of classes"
     (is (= (attrs/compile-config-kv :class ["a" "b" "c"]) "a b c")))
   #_(testing "Map of class -> boolean"
@@ -22,7 +24,7 @@
 (deftest test-set-id-class
   (testing "Hiccup classes should preceding attribute classes"
     (is (= (attrs/set-id-class {:class "a"} (attrs/parse-tag (name :div.b)))
-           {:class "b a"})))
+           {:class `(clojure.core/str "b" " " "a")})))
   (testing "Attribute ID has higher priority than Hiccup ID"
     (is (= (attrs/set-id-class {:id "a"} (attrs/parse-tag (name :div#b)))
            {:id "a"}))))

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -88,6 +88,7 @@
                (as-string #el [null-comp true]))))
 
 
+#_
 (deftest test-class-from-collection
   (is (= (as-string #el [:p {:class ["a" "b" "c" "d"]}])
          (as-string #el [:p {:class "a b c d"}])))
@@ -113,7 +114,7 @@
   (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
                (as-string #el [:custom-element {:class "foobar"} "foo"])))
 
-  (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
+  (is (re-find #"<custom-element class=\"foobar \">foo</custom-element>"
                (as-string #el [:custom-element.foobar {} "foo"]))))
 
 (deftest test-fragments


### PR DESCRIPTION
Removing support for collection-based class names `:class [x y z]`, with this change only strings as class names are supported. This is a simplification to avoid bugs related to compile-time merging of various possible shapes of data being passed as a class name. We may revisit this later.