### PR TITLE
fix codegen for zero args components

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -2,11 +2,20 @@
   "Public API"
   (:require [uix.compiler.aot]))
 
+(defn- no-args-component [sym body]
+  `(defn ~sym []
+     ~@body))
+
+(defn- with-args-component [sym args body]
+  `(defn ~sym [props#]
+     (let [~args (cljs.core/array (glue-args props#))]
+       ~@body)))
+
 (defmacro defui
   "Compiles UIx component into React component at compile-time."
   [sym args & body]
   `(do
-     (defn ~sym [props#]
-       (let [~args (cljs.core/array (glue-args props#))]
-         ~@body))
+     ~(if (empty? args)
+        (no-args-component sym body)
+        (with-args-component sym args body))
      (with-name ~sym)))


### PR DESCRIPTION
This PR fixes codegen for component definitions that doesn't expect any props, previously we'd generate a function expecting props object eve though the definition clearly states that no args are expected
```clojure
(defui component []
  ...)
```