### PR TITLE
uix.core/source to retrieve source code of a component

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -1,6 +1,7 @@
 (ns uix.core
   "Public API"
-  (:require [uix.compiler.aot]))
+  (:require [uix.compiler.aot]
+            [uix.source]))
 
 (defn- no-args-component [sym body]
   `(defn ~sym []
@@ -14,8 +15,14 @@
 (defmacro defui
   "Compiles UIx component into React component at compile-time."
   [sym args & body]
+  (uix.source/register-symbol! sym)
   `(do
      ~(if (empty? args)
         (no-args-component sym body)
         (with-args-component sym args body))
      (with-name ~sym)))
+
+(defmacro source
+  "Returns source string of UIx component"
+  [sym]
+  (uix.source/source sym))

--- a/core/src/uix/source.clj
+++ b/core/src/uix/source.clj
@@ -1,0 +1,33 @@
+(ns uix.source
+  "Getting source of UIx components at macro expansion time"
+  (:require [clojure.java.io :as io]
+            [clojure.tools.reader.reader-types :as readers]
+            [clojure.tools.reader :as reader]
+            [cljs.tagged-literals :as tags])
+  (:import (java.io PushbackReader)))
+
+(def components (atom {}))
+
+(defn register-symbol! [sym]
+  (swap! components assoc sym sym))
+
+;; from cljs.repl/source-fn
+(defn- source-fn [sym]
+  (let [v (meta sym)]
+    (when-let [filepath (:file v)]
+      (let [f (io/file filepath)
+            f (if (.exists f)
+                f
+                (io/resource filepath))]
+        (when f
+          (with-open [pbr (PushbackReader. (io/reader f))]
+            (let [rdr (readers/source-logging-push-back-reader pbr)]
+              (dotimes [_ (dec (:line v))] (readers/read-line rdr))
+              (binding [reader/*alias-map* identity
+                        reader/*data-readers* tags/*cljs-data-readers*]
+                (-> (reader/read {:read-cond :allow :features #{:cljs}} rdr)
+                    meta
+                    :source)))))))))
+
+(defn source [sym]
+  (source-fn (@components sym)))


### PR DESCRIPTION
This PR adds `uix.core/source` macro that returns a string of source code of UIx component
```clojure
(defui component []
  #el [:button {} "hit me"])

(uix.core/source component) ;; returns the above in a form of a string
```