### PR TITLE
bring back support for collection classes

### DIFF
--- a/core/src/uix/compiler/attributes.clj
+++ b/core/src/uix/compiler/attributes.clj
@@ -26,8 +26,8 @@
               ;; Merge classes
               (or class props-class)
               (assoc :class (cond
-                              (vector? props-class) `(.join (cljs.core/array ~class ~@props-class) " ")
-                              props-class `(.join (cljs.core/array ~class ~props-class) " ")
+                              (vector? props-class) `(join-class-names (cljs.core/array ~class ~@props-class))
+                              props-class `(join-class-names (cljs.core/array ~class ~props-class))
                               :else class))))
     props))
 

--- a/core/src/uix/compiler/attributes.clj
+++ b/core/src/uix/compiler/attributes.clj
@@ -17,14 +17,18 @@
   "Takes attributes map and parsed tag, and returns attributes merged with class names and id"
   [props [_ id class]]
   (if (or (map? props) (nil? props))
-    (cond-> props
-            ;; Only use ID from tag keyword if no :id in props already
-            (and (some? id) (nil? (get props :id)))
-            (assoc :id id)
+    (let [props-class (get props :class)]
+      (cond-> props
+              ;; Only use ID from tag keyword if no :id in props already
+              (and (some? id) (nil? (get props :id)))
+              (assoc :id id)
 
-            ;; Merge classes
-            class
-            (assoc :class `(str ~class " " ~(get props :class))))
+              ;; Merge classes
+              (or class props-class)
+              (assoc :class (cond
+                              (vector? props-class) `(.join (cljs.core/array ~class ~@props-class) " ")
+                              props-class `(.join (cljs.core/array ~class ~props-class) " ")
+                              :else class))))
     props))
 
 (defn camel-case

--- a/core/src/uix/compiler/attributes.clj
+++ b/core/src/uix/compiler/attributes.clj
@@ -26,8 +26,8 @@
               ;; Merge classes
               (or class props-class)
               (assoc :class (cond
-                              (vector? props-class) `(join-class-names (cljs.core/array ~class ~@props-class))
-                              props-class `(join-class-names (cljs.core/array ~class ~props-class))
+                              (vector? props-class) `(class-names ~class ~@props-class)
+                              props-class `(class-names ~class ~props-class)
                               :else class))))
     props))
 

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -118,6 +118,9 @@
             (and (some? classes) (pos? (.-length classes)))
             (assoc :class (class-names classes (get props :class))))))
 
+(defn join-class-names [^array arr]
+  (.join (.filter arr some?) " "))
+
 (defn convert-props
   "Converts `props` Clojure map into JS object suitable for
   passing as `props` object into `React.crteateElement`
@@ -126,18 +129,15 @@
   - `id-class` — a triplet of parsed tag, id and class names
   - `shallow?` — indicates whether `props` map should be converted shallowly or not"
   [props id-class ^boolean shallow?]
-  (let [class (get props :class)
-        props (cond-> props
-                  class (assoc :class class)
-                  :always (set-id-class id-class))]
-    (cond
-      ^boolean (aget id-class 3)
-      (convert-custom-prop-value props)
+  #_(let [props (set-id-class props id-class)])
+  (cond
+    ^boolean (aget id-class 3)
+    (convert-custom-prop-value props)
 
-      shallow?
-      (convert-prop-value-shallow props)
+    shallow?
+    (convert-prop-value-shallow props)
 
-      :else (convert-prop-value props))))
+    :else (convert-prop-value props)))
 
 (defn interpret-attrs
   "Returns a tuple of attributes and a child element

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -24,7 +24,7 @@
 (deftest test-set-id-class
   (testing "Hiccup classes should preceding attribute classes"
     (is (= (attrs/set-id-class {:class "a"} (attrs/parse-tag (name :div.b)))
-           {:class `(clojure.core/str "b" " " "a")})))
+           {:class `(uix.compiler.attributes/join-class-names (cljs.core/array "b" "a"))})))
   (testing "Attribute ID has higher priority than Hiccup ID"
     (is (= (attrs/set-id-class {:id "a"} (attrs/parse-tag (name :div#b)))
            {:id "a"}))))

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -12,19 +12,12 @@
 (deftest test-class-names
   (is (= (attrs/compile-config-kv :class nil) nil))
   (testing "Named types"
-    (is (= (attrs/compile-config-kv :class "a") "a"))
-    #_
-    (is (= (attrs/compile-config-kv :class :a) :a)))
-  #_
-  (testing "Collection of classes"
-    (is (= (attrs/compile-config-kv :class ["a" "b" "c"]) "a b c")))
-  #_(testing "Map of class -> boolean"
-      (is (= (attrs/compile-config-kv :class {:c1 true :c2 false}) "c1"))))
+    (is (= (attrs/compile-config-kv :class "a") "a"))))
 
 (deftest test-set-id-class
   (testing "Hiccup classes should preceding attribute classes"
     (is (= (attrs/set-id-class {:class "a"} (attrs/parse-tag (name :div.b)))
-           {:class `(uix.compiler.attributes/join-class-names (cljs.core/array "b" "a"))})))
+           {:class `(uix.compiler.attributes/class-names "b" "a")})))
   (testing "Attribute ID has higher priority than Hiccup ID"
     (is (= (attrs/set-id-class {:id "a"} (attrs/parse-tag (name :div#b)))
            {:id "a"}))))

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -87,15 +87,16 @@
   (is (re-find #"test-null-component"
                (as-string #el [null-comp true]))))
 
-
-#_
 (deftest test-class-from-collection
+  #_
   (is (= (as-string #el [:p {:class ["a" "b" "c" "d"]}])
          (as-string #el [:p {:class "a b c d"}])))
+  (is (= (as-string #el [:p.x {:class ["a" "b" "c" "d"]}])
+         (as-string #el [:p {:class "x a b c d"}])))
   #_(is (= (as-string #el [:p {:class ["a" nil "b" false "c" nil]}])
            (as-string #el [:p {:class "a b c"}])))
-  (is (= (as-string #el [:p {:class #{"a" "b" "c"}}])
-         (as-string #el [:p {:class "a b c"}]))))
+  #_(is (= (as-string #el [:p {:class #{"a" "b" "c"}}])
+           (as-string #el [:p {:class "a b c"}]))))
 
 (uix.core/defui key-tester []
   #el [:div {}
@@ -114,7 +115,7 @@
   (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
                (as-string #el [:custom-element {:class "foobar"} "foo"])))
 
-  (is (re-find #"<custom-element class=\"foobar \">foo</custom-element>"
+  (is (re-find #"<custom-element class=\"foobar\">foo</custom-element>"
                (as-string #el [:custom-element.foobar {} "foo"]))))
 
 (deftest test-fragments

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -88,15 +88,15 @@
                (as-string #el [null-comp true]))))
 
 (deftest test-class-from-collection
-  #_
   (is (= (as-string #el [:p {:class ["a" "b" "c" "d"]}])
          (as-string #el [:p {:class "a b c d"}])))
   (is (= (as-string #el [:p.x {:class ["a" "b" "c" "d"]}])
          (as-string #el [:p {:class "x a b c d"}])))
-  #_(is (= (as-string #el [:p {:class ["a" nil "b" false "c" nil]}])
-           (as-string #el [:p {:class "a b c"}])))
-  #_(is (= (as-string #el [:p {:class #{"a" "b" "c"}}])
-           (as-string #el [:p {:class "a b c"}]))))
+  (is (= (as-string #el [:p {:class ["a" nil "b" false "c" nil]}])
+         (as-string #el [:p {:class "a b c"}])))
+  (let [x ["b" "c"]]
+    (is (= (as-string #el [:p.a {:class x}])
+           (as-string #el [:p {:class "a b c"}])))))
 
 (uix.core/defui key-tester []
   #el [:div {}


### PR DESCRIPTION
This PR brings back support for collection classes `:class ["x" "y"]`