### PR TITLE
support attr values as keywords

### DIFF
--- a/core/src/uix/compiler/attributes.clj
+++ b/core/src/uix/compiler/attributes.clj
@@ -53,13 +53,23 @@
     (reduce-kv #(assoc %1 (camel-case %2) %3) {} m)
     m))
 
+(defn convert-value [v]
+  (if (symbol? v)
+    `(keyword->string ~v)
+    v))
+
+(defn convert-values [m]
+  (if (map? m)
+    (reduce-kv #(assoc %1 (camel-case %2) (convert-value %3)) {} m)
+    m))
+
 (defmulti compile-config-kv (fn [name value] name))
 
 (defmethod compile-config-kv :style [name value]
-  (camel-case-keys value))
+  (convert-values (camel-case-keys value)))
 
 (defmethod compile-config-kv :default [name value]
-  value)
+  (convert-value value))
 
 (defn compile-attrs
   "Takes map of attributes and returns same map with keys translated from Hiccup to React naming conventions"

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -26,6 +26,11 @@
     name-str
     (.replace name-str cc-regexp cc-fn)))
 
+(defn keyword->string [x]
+  (if (keyword? x)
+    (-name ^not-native x)
+    x))
+
 (defn cached-prop-name [k]
   (if (keyword? k)
     (let [name-str (-name ^not-native k)]

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -101,6 +101,18 @@
     (is (= (as-string #el [:p.a {:class x}])
            (as-string #el [:p {:class "a b c"}])))))
 
+(deftest test-keyword-attrs-value
+  (is (= (as-string #el [:p {:title :hello}])
+         (as-string #el [:p {:title "hello"}])))
+  (let [x :hello]
+    (is (= (as-string #el [:p {:title x}])
+           (as-string #el [:p {:title "hello"}]))))
+  (is (= (as-string #el [:p {:style {:text-align :center}}])
+         (as-string #el [:p {:style {:text-align "center"}}])))
+  (let [x :center]
+    (is (= (as-string #el [:p {:style {:text-align x}}])
+           (as-string #el [:p {:style {:text-align "center"}}])))))
+
 (uix.core/defui key-tester []
   #el [:div {}
        (for [i (range 3)]


### PR DESCRIPTION
This PR adds support for runtime keyword values for DOM and style attributes
```clojure
(let [x :hello]
  #el [:p {:title x}])
```