### PR TITLE
preserve component name in advanced builds

### DIFF
--- a/core/src/uix/compiler/debug.cljs
+++ b/core/src/uix/compiler/debug.cljs
@@ -29,7 +29,10 @@
         (if (string? name)
           name))))
 
-(defn with-name [^js f]
-  (when-let [component-name (effective-component-name f)]
+(defn with-name
+  ([^js f ns-str sym-str]
+   (set! (.-displayName f) (str ns-str "/" sym-str)))
+  ([^js f]
+   (when-let [component-name (effective-component-name f)]
     (when-some [display-name (format-display-name component-name)]
-      (set! (.-displayName f) display-name))))
+      (set! (.-displayName f) display-name)))))

--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -44,7 +44,7 @@
        ~(if (empty? args)
           (no-args-component fname fdecl)
           (with-args-component fname args fdecl))
-       (with-name ~sym))))
+       (with-name ~sym ~(-> &env :ns :name str) ~(str sym)))))
 
 (defmacro source
   "Returns source string of UIx component"


### PR DESCRIPTION
This PR makes sure that component names (`ns/name`) are preserved in `:advanced` builds, to make debugging a bit easier in prod builds

Currently when looking at UI tree in React DevTools, all component names are munged
<img width="258" alt="Screenshot 2021-11-16 at 12 38 13 PM" src="https://user-images.githubusercontent.com/1355501/141970137-5e9674b8-9eaf-4f32-8f11-d134745dffbc.png">
