### PR TITLE
adapt React keys warning

### DIFF
--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -58,7 +58,7 @@
                            (-reset! o (apply f (-deref o) a b xs))))))
         derive-state (fn [error] #js {:argv (error->state error)})
         render (fn []
-                 (this-as this
+                 (this-as ^react/Component this
                    (let [args (.. this -props -argv)
                          state (.-state this)]
                      ;; `render-fn` should return compiled Hiccup


### PR DESCRIPTION
Formats component names, to log
```
Warning: Each child in a list should have a unique "key" prop.
Check the render method of pitch.components.workspace-switcher.views.workspace-switcher-content*.
```

instead of 
```
Warning: Each child in a list should have a unique "key" prop.
Check the render method of `pitch.components.workspace_switcher.views.workspace_switcher_content_STAR_`.
```