### PR TITLE
validate UTL in dev

### DIFF
--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -13,7 +13,7 @@
 
 (defn >el [tag attrs-children children]
   (let [args (-> #js [tag] (.concat attrs-children) (.concat children))]
-    (when ^goog.DEBUG
+    (when ^boolean goog.DEBUG
       (validate-children (.slice args 2) false))
     (.apply react/createElement nil args)))
 

--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -2,10 +2,19 @@
   "Runtime helpers for Hiccup compiled into React.js"
   (:require [react :as react]
             [uix.compiler.alpha :as r]
-            [uix.compiler.attributes]))
+            [uix.compiler.attributes]
+            [uix.lib :refer [doseq-loop]]))
+
+(defn- validate-children [children deep?]
+  (doseq-loop [child children]
+    (cond
+      (and (not deep?) (sequential? child)) (validate-children child true)
+      (vector? child) (throw (js/Error. (str "Hiccup is not valid as UIx child (found: " child "). If you meant to render an element, tag it with #el, i.e. #el " child))))))
 
 (defn >el [tag attrs-children children]
   (let [args (-> #js [tag] (.concat attrs-children) (.concat children))]
+    (when ^goog.DEBUG
+      (validate-children (.slice args 2) false))
     (.apply react/createElement nil args)))
 
 (def suspense react/Suspense)


### PR DESCRIPTION
This PR adds dev-only UTL validation to print a meaningful error when Hiccup is passed as a child element into UIx element.

Instead of 
```
Uncaught  Error: Uncaught : Objects are not valid as a React child (found: object with keys {ns, name, fqn, _hash, cljs$lang$protocol_mask$partition0$, cljs$lang$protocol_mask$partition1$}). If you meant to render a collection of children, use an array instead.
```

we print the following when a child element is a vector
```
Uncaught  Error: Uncaught : Hiccup is not valid as UIx child (found: [:div 0]). If you meant to render an element, tag it with #el, i.e. #el [:div 0]
```