### PR TITLE
improved children validation

### DIFF
--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -5,16 +5,31 @@
             [uix.compiler.attributes]
             [uix.lib :refer [doseq-loop]]))
 
-(defn- validate-children [children deep?]
+(defn hiccup? [el]
+  (when (vector? el)
+    (let [tag (nth el 0 nil)]
+      (or (keyword? tag)
+          (symbol? tag)
+          (fn? tag)
+          (instance? MultiFn tag)))))
+
+
+(defn validate-children [children]
   (doseq-loop [child children]
     (cond
-      (and (not deep?) (sequential? child)) (validate-children child true)
-      (vector? child) (throw (js/Error. (str "Hiccup is not valid as UIx child (found: " child "). If you meant to render an element, tag it with #el, i.e. #el " child))))))
+      (hiccup? child)
+      (throw (js/Error. (str "Hiccup is not valid as UIx child (found: " child ").\n"
+                             "If you meant to render UIx element, tag it with #el, i.e. #el " child "\n"
+                             "If you meant to render Reagent element, wrap is with r/as-element, i.e. (r/as-element " child ")")))
+
+      (sequential? child)
+      (validate-children child)))
+  true)
 
 (defn >el [tag attrs-children children]
   (let [args (-> #js [tag] (.concat attrs-children) (.concat children))]
     (when ^boolean goog.DEBUG
-      (validate-children (.slice args 2) false))
+      (validate-children (.slice args 2)))
     (.apply react/createElement nil args)))
 
 (def suspense react/Suspense)

--- a/core/test/uix/aot_test.cljs
+++ b/core/test/uix/aot_test.cljs
@@ -1,0 +1,20 @@
+(ns uix.aot-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [uix.compiler.aot :as aot]))
+
+(defmulti x identity)
+
+(deftest test-validate-children
+  (when ^boolean goog.DEBUG
+    (testing "should throw for Hiccup child"
+      (is (thrown-with-msg? js/Error #"\(found: \[:div\]\)" (aot/validate-children #js [[:div]])))
+      (is (thrown-with-msg? js/Error #"\(found: \[div\]\)" (aot/validate-children #js [['div]])))
+      (is (thrown-with-msg? js/Error #"\(found: \[#object\[cljs\$core\$inc\]\]\)" (aot/validate-children #js [[inc]])))
+      (is (thrown-with-msg? js/Error #"\(found: \[\#object\[cljs.core.MultiFn\]\]\)" (aot/validate-children #js [[x]])))))
+
+  (testing "should throw for nested Hiccup child"
+    (is (thrown-with-msg? js/Error #"\(found: \[:div 3\]\)" (aot/validate-children #js [1 [2 [:div 3]]]))))
+
+  (testing "should not throw when there's no Hiccup children"
+    (is (aot/validate-children #js [1 2 3]))
+    (is (aot/validate-children #js [1 [2 3] [4 [5 6]]]))))

--- a/core/test/uix/test_runner.cljs
+++ b/core/test/uix/test_runner.cljs
@@ -1,5 +1,6 @@
 (ns uix.test-runner
   (:require [cljs.test]
+            [uix.aot-test]
             [uix.core-test]
             [uix.compiler-test]
             [uix.hooks-test]))
@@ -14,6 +15,7 @@
 
 (cljs.test/run-tests
   (cljs.test/empty-env)
+  'uix.aot-test
   'uix.core-test
   'uix.compiler-test
   'uix.hooks-test)


### PR DESCRIPTION
This PR fixes a couple of issues and improves child elements validation. Additionally the error message was improved to help when mixing Reagent with UIx


```
Uncaught Error: Hiccup is not valid as UIx child (found: [:h2 "hello reagent"]).
If you meant to render UIx element, tag it with #el, i.e. #el [:h2 "hello reagent"]
If you meant to render Reagent element, wrap is with r/as-element, i.e. (r/as-element [:h2 "hello reagent"])
```