### PR TITLE
Validate UTL component elements

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -19,7 +19,18 @@
 (defn as-react [f]
   #(f (bean/bean %)))
 
+(defn validate-component [^js component-type]
+  (when-not ^boolean (.-uix-component? component-type)
+    (let [name-str (or (.-displayName component-type)
+                       (.-name component-type))]
+      (throw (js/Error. (str "Invalid use of a non-UIx component " name-str " in #el form.\n"
+                             "If you meant to render React element, use :> syntax for interop with JavaScript components, i.e. #el [:> " name-str "]\n"
+                             "If you meant to render Reagent element, make it Hiccup wrapped with r/as-element, i.e. (r/as-element [" name-str "])")))))
+  true)
+
 (defn component-element [component-type ^js props-children children]
+  (when ^boolean goog.DEBUG
+    (validate-component component-type))
   (let [props (aget props-children 0)
         js-props (if-some [key (:key props)]
                    #js {:key key :argv (dissoc props :key)}

--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -20,7 +20,7 @@
       (hiccup? child)
       (throw (js/Error. (str "Hiccup is not valid as UIx child (found: " child ").\n"
                              "If you meant to render UIx element, tag it with #el, i.e. #el " child "\n"
-                             "If you meant to render Reagent element, wrap is with r/as-element, i.e. (r/as-element " child ")")))
+                             "If you meant to render Reagent element, wrap it with r/as-element, i.e. (r/as-element " child ")")))
 
       (sequential? child)
       (validate-children child)))

--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -44,6 +44,7 @@
        ~(if (empty? args)
           (no-args-component fname fdecl)
           (with-args-component fname args fdecl))
+       (set! (.-uix-component? ~(with-meta sym {:tag 'js})) true)
        (with-name ~sym ~(-> &env :ns :name str) ~(str sym)))))
 
 (defmacro source

--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -24,6 +24,7 @@
                 (aset ctor (name k) v))
     (doseq-loop [[k v] prototype]
                 (aset (.-prototype ctor) (name k) v))
+    (set! (.-uix-component? ctor) true)
     ctor))
 
 (defn create-error-boundary

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -201,5 +201,18 @@
       (is (.-type el) "h1")
       (is (.-children props) "TEXT")))
 
+(deftest test-validate-component
+  (is (thrown-with-msg? js/Error #"Invalid use of a non-UIx component test in #el form\..*"
+                        (uixc/validate-component #js {:name "test"})))
+  (when ^boolean goog.DEBUG
+    (is (thrown-with-msg? js/Error #"Invalid use of a non-UIx component cljs\$core\$inc in #el form\..*"
+                          #el [inc])))
+  (let [target #js {:name "test"}]
+    (set! (.-uix-component? target) true)
+    (is (true? (uixc/validate-component target))))
+  (when ^boolean goog.DEBUG
+    (uix.core/defui test-comp [] "x")
+    (is (= test-comp (.-type #el [test-comp])))))
+
 (defn -main []
   (run-tests))


### PR DESCRIPTION
This PR adds dev-only check to validate component types in UTL forms.

Only `defui` components can be created via `#el [component]` forms. For interop with JS React components `:>` syntax should be used. Other than that, when something that is not a `defui` is used in `#el [component]` form, the following exception will be thrown:
```
Error: Uncaught : Invalid use of a non-UIx component cljs$core$inc in #el form.
If you meant to render React element, use :> syntax for interop with JavaScript components, i.e. #el [:> cljs$core$inc]
If you meant to render Reagent element, make it Hiccup wrapped with r/as-element, i.e. (r/as-element [cljs$core$inc])
```