### PR TITLE
Improve UIx stack traces

### DIFF
--- a/core/src/uix/compiler/debug.cljs
+++ b/core/src/uix/compiler/debug.cljs
@@ -32,10 +32,13 @@
 
 (defn with-name
   ([^js f ns-str sym-str]
-   (set! (.-displayName f) (str ns-str "/" sym-str)))
+   (let [f-name (str ns-str "/" sym-str)]
+     (js/Object.defineProperty f "name" #js {:value f-name})
+     (set! (.-displayName f) f-name)))
   ([^js f]
    (when-let [component-name (effective-component-name f)]
     (when-some [display-name (format-display-name component-name)]
+      (js/Object.defineProperty f "name" #js {:value display-name})
       (set! (.-displayName f) display-name)))))
 
 ;; ============ Adapting React warnings to UIx ============


### PR DESCRIPTION
This PR improves UIx stack traces to have formatted components names instead of mangled names, e.g. `app.components/quick-view` instead of `app$components$quick_view`