### PR TITLE
assert number of args in defui

### DIFF
--- a/core/test/uix/core_test.clj
+++ b/core/test/uix/core_test.clj
@@ -1,5 +1,6 @@
 (ns uix.core-test
   (:require [clojure.test :refer :all]
+            [uix.core]
             [uix.core.lazy-loader :refer [require-lazy]]))
 
 (require-lazy '[clojure.string :refer [blank?]])
@@ -13,3 +14,9 @@
       (macroexpand-1 '(require-lazy '[clojure.string :as str]))
       (catch Exception e
         (is (some? e))))))
+
+(deftest test-parse-sig
+  (is (thrown-with-msg? AssertionError #"uix.core\/defui doesn't support multi-arity"
+                        (uix.core/parse-sig 'component-name '(([props]) ([props x])))))
+  (is (thrown-with-msg? AssertionError #"uix.core\/defui should be a single-arity component"
+        (uix.core/parse-sig 'component-name '([props x])))))


### PR DESCRIPTION
Validating number of arguments in `defui` declarations, since only one argument of props map is expected. Should be helpful when porting Reagent code.

<img width="1075" alt="Screenshot 2021-12-16 at 1 49 48 PM" src="https://user-images.githubusercontent.com/1355501/146366633-932e93af-abd1-4799-a7fb-4fbe292396a1.png">
