### PR TITLE
throw an error when #el is used on non-vector expression

### DIFF
--- a/core/src/data_readers.clj
+++ b/core/src/data_readers.clj
@@ -1,1 +1,1 @@
-{el uix.compiler.aot/compile-html}
+{el uix.compiler.aot/el-tag}

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -98,4 +98,9 @@
     (compile-element expr)
     expr))
 
+(defn el-tag [expr]
+  (if (vector? expr)
+    (compile-element expr)
+    `(throw (js/Error. (str "#el should only be used together with vectors, found: #el " ~expr)))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This PR adds validation step, to make sure that `#el` is not used on non-vector literal expressions. When used, the runtime will throw an error.