### PR TITLE
check if hooks are used in a branch or in a loop at compile time

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -2,7 +2,8 @@
   "Public API"
   (:require [uix.compiler.aot]
             [uix.source]
-            [cljs.core]))
+            [cljs.core]
+            [uix.hooks.linter :as hooks.linter]))
 
 (defn- no-args-component [sym body]
   `(defn ~sym []
@@ -45,6 +46,7 @@
 
   (let [[fname args fdecl] (parse-sig sym fdecl)]
     (uix.source/register-symbol! sym)
+    (hooks.linter/lint! sym fdecl &env)
     `(do
        ~(if (empty? args)
           (no-args-component fname fdecl)

--- a/core/src/uix/hooks/linter.clj
+++ b/core/src/uix/hooks/linter.clj
@@ -4,6 +4,7 @@
             [cljs.analyzer :as ana]))
 
 (def ^:dynamic *component-context* nil)
+(def ^:dynamic *source-context* false)
 (def ^:dynamic *in-branch?* false)
 (def ^:dynamic *in-loop?* false)
 
@@ -101,6 +102,7 @@
 
 (defn add-error! [form type]
   (swap! *component-context* update :errors conj {:source form
+                                                  :source-context *source-context*
                                                   :type type}))
 
 (defn lint-hooks!*
@@ -118,7 +120,8 @@
               nil)
 
           (and (list? form) (or (not *in-branch?*) (not *in-loop?*)))
-          (maybe-lint form)
+          (binding [*source-context* form]
+            (maybe-lint form))
 
           :else form))
       expr)

--- a/core/src/uix/hooks/linter.clj
+++ b/core/src/uix/hooks/linter.clj
@@ -1,0 +1,165 @@
+(ns uix.hooks.linter
+  (:require [clojure.walk]
+            [clojure.pprint :as pp]))
+
+(def ^:dynamic *component-context* nil)
+(def ^:dynamic *source-context* false)
+(def ^:dynamic *in-branch?* false)
+(def ^:dynamic *in-loop?* false)
+
+(defn hook? [sym]
+  (and (symbol? sym)
+       (some? (re-find #"^use-|use[A-Z]" (name sym)))))
+
+(declare lint-hooks!*)
+
+(def forms
+  '{:when #{when when-not when-let when-some when-first}
+    :if #{if if-not if-let if-some}
+    :logical #{and or}
+    :cond #{cond}
+    :cond-threaded #{cond-> cond->>}
+    :some-threaded #{some-> some->>}
+    :condp #{condp}
+    :case #{case}
+    :loop #{loop}
+    :for  #{for doseq}
+    :iter-fn #{map mapv map-indexed filter filterv reduce reduce-kv keep keep-indexed
+               remove mapcat drop-while take-while group-by partition-by split-with
+               sort-by some}})
+
+(defmulti maybe-lint
+          (fn [[sym :as form]]
+            (reduce-kv
+              (fn [ret kw forms]
+                (if (forms sym)
+                  (reduced kw)
+                  ret))
+              form
+              forms)))
+
+(defmethod maybe-lint :default [form]
+  form)
+
+(defmethod maybe-lint :when [[_ test & body]]
+  (lint-hooks!* test :in-branch? false)
+  (run! #(lint-hooks!* % :in-branch? true) body))
+
+(defmethod maybe-lint :if [[_ test then else]]
+  (lint-hooks!* test :in-branch? false)
+  (lint-hooks!* then :in-branch? true)
+  (lint-hooks!* else :in-branch? true))
+
+(defmethod maybe-lint :logical [[_ test & tests]]
+  (lint-hooks!* test :in-branch? false)
+  (run! #(lint-hooks!* % :in-branch? true) tests))
+
+(defmethod maybe-lint :cond [[_ clause & clauses]]
+  (lint-hooks!* clause :in-branch? false)
+  (run! #(lint-hooks!* % :in-branch? true) clauses))
+
+(defmethod maybe-lint :condp [[_ pred e clause & clauses]]
+  (lint-hooks!* pred :in-branch? false)
+  (lint-hooks!* e :in-branch? false)
+  (lint-hooks!* clause :in-branch? false)
+  (run! #(lint-hooks!* % :in-branch? true) clauses))
+
+(defmethod maybe-lint :cond-threaded [[_ e & clauses]]
+  (lint-hooks!* e :in-branch? false)
+  (->> (partition 2 clauses)
+       (run! (fn [[test expr]]
+               (lint-hooks!* test :in-branch? false)
+               (lint-hooks!* expr :in-branch? true)))))
+
+(defmethod maybe-lint :some-threaded [[_ e clause & clauses]]
+  (lint-hooks!* e :in-branch? false)
+  (lint-hooks!* clause :in-branch? false)
+  (run! #(lint-hooks!* % :in-branch? true) clauses))
+
+(defmethod maybe-lint :case [[_ e clause & clauses]]
+  (lint-hooks!* e :in-branch? false)
+  (lint-hooks!* clause :in-branch? false)
+  (run! #(lint-hooks!* % :in-branch? true) clauses))
+
+(defmethod maybe-lint :loop [[_ bindings & body]]
+  (lint-hooks!* bindings :in-loop? false)
+  (run! #(lint-hooks!* % :in-loop? true) body))
+
+(defmethod maybe-lint :for [[_ bindings & body]]
+  (let [[binding & bindings] (partition 2 bindings)]
+    (lint-hooks!* (second binding) :in-loop? false)
+    (run! (fn [[v expr]] (lint-hooks!* expr :in-loop? true))
+          bindings)
+    (run! #(lint-hooks!* % :in-loop? true) body)))
+
+(defmethod maybe-lint :iter-fn [[_ f :as form]]
+  (when (and (list? f)
+             ('#{fn fn*} (first f))
+             (vector? (second f)))
+    (let [[_ _ & body] f]
+      (run! #(lint-hooks!* % :in-loop? true) body))))
+
+(defn add-error! [form type]
+  (swap! *component-context* update :errors conj {:source form
+                                                  :source-context *source-context*
+                                                  :type type}))
+
+(defn lint-hooks!*
+  [expr & {:keys [in-branch? in-loop?]
+           :or {in-branch? *in-branch?*
+                in-loop? *in-loop?*}}]
+  (binding [*in-branch?* in-branch?
+            *in-loop?* in-loop?]
+    (clojure.walk/prewalk
+      (fn [form]
+        (cond
+          (and (list? form) (hook? (first form)))
+          (do (when *in-branch?* (add-error! form :hook-in-branch))
+              (when *in-loop?* (add-error! form :hook-in-loop))
+              nil)
+
+          (and (list? form) (or (not *in-branch?*) (not *in-loop?*)))
+          (binding [*source-context* form]
+            (maybe-lint form))
+
+          :else form))
+      expr)
+    nil))
+
+(defn lint-hooks! [exprs]
+  (run! lint-hooks!* exprs))
+
+(defmulti error->msg (fn [_ err] (:type err)))
+
+(defmethod error->msg :hook-in-branch [{:keys [name column line]} {:keys [source source-context]}]
+  ;; https://github.com/facebook/react/blob/d63cd972454125d4572bb8ffbfeccbdf0c5eb27b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L457
+  (str "React Hook " source " is called conditionally.\n"
+       "React Hooks must be called in the exact same order in every component render.\n"
+       "Found in " name ", at " line ":" column "\n"
+       "Problematic code: " (with-out-str (pp/pprint source-context))))
+
+(defmethod error->msg :hook-in-loop [{:keys [name column line]} {:keys [source source-context]}]
+  ;; https://github.com/facebook/react/blob/d63cd972454125d4572bb8ffbfeccbdf0c5eb27b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L438
+  (str "React Hook " source " may be executed more than once. "
+       "Possibly because it is called in a loop. "
+       "React Hooks must be called in the exact same order in "
+       "every component render.\n"
+       "Found in " name ", at " line ":" column "\n"
+       "Problematic code: " (with-out-str (pp/pprint source-context))))
+
+(defn lint! [sym form env]
+  (binding [*component-context* (atom {:errors []})]
+    (lint-hooks! form)
+    (let [{:keys [errors]} @*component-context*
+          {:keys [column line]} env]
+      (binding [*out* *err*]
+        (->> errors
+             (map (fn [err]
+                    [(error->msg
+                       {:name (str (-> env :ns :name) "/" sym)
+                        :column column
+                        :line line}
+                       err)
+                     (:type err)]))
+             (run! (fn [[msg tag]] (throw (ex-info msg {:tag tag})))))))))
+

--- a/core/test/uix/hooks/linter_test.clj
+++ b/core/test/uix/hooks/linter_test.clj
@@ -1,0 +1,206 @@
+(ns uix.hooks.linter-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [uix.hooks.linter :as hooks.linter]))
+
+(defn lint-syms [syms expr-fn]
+  (binding [hooks.linter/*component-context* (atom {:errors []})]
+    (let [exprs (map expr-fn syms)
+          _ (hooks.linter/lint-hooks! exprs)
+          errors (:errors @hooks.linter/*component-context*)]
+      [exprs (map :source-context errors)])))
+
+(deftest test-lint-when
+  (testing "hook in a branch should error"
+    (let [[exprs errors] (lint-syms
+                           (:when hooks.linter/forms)
+                           (fn [sym] (list sym 'x '(use-state 0))))]
+      (is (= exprs errors))))
+  (testing "hook in test expr should not error"
+    (let [[exprs errors] (lint-syms
+                           '[when when-not]
+                           (fn [sym] (list sym '(use-state 0) 'x)))]
+      (is (zero? (count errors)))))
+  (testing "hook in test bindings should not error"
+    (let [[exprs errors] (lint-syms
+                           '[when-let when-some when-first]
+                           (fn [sym] (list sym '[x (use-state 0)])))]
+      (is (zero? (count errors))))))
+
+(deftest test-lint-if
+  (testing "hook in a branch should error"
+    (let [[exprs errors] (lint-syms
+                           (:if hooks.linter/forms)
+                           (fn [sym] (list sym 'test 'x '(use-state 0))))]
+      (is (= exprs errors))))
+  (testing "hook in test expr should not error"
+    (let [[exprs errors] (lint-syms
+                           '[if if-not]
+                           (fn [sym] (list sym '(use-state 0) 'then 'else)))]
+      (is (zero? (count errors)))))
+  (testing "hook in test expr should not error"
+    (let [[exprs errors] (lint-syms
+                           '[if-let if-some]
+                           (fn [sym] (list sym '[x (use-state 0)] 'then 'else)))]
+      (is (zero? (count errors))))))
+
+(deftest test-lint-logical
+  (testing "hook at the first test position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:logical hooks.linter/forms)
+                           (fn [sym] (list sym '(use-state 0) 'test)))]
+      (is (zero? (count errors)))))
+  (testing "hook at second+ test position should error"
+    (let [[exprs errors] (lint-syms
+                           (:logical hooks.linter/forms)
+                           (fn [sym] (list sym 'test '(use-state 0))))]
+      (is (= exprs errors)))))
+
+(deftest test-lint-cond
+  (testing "hook at the first test position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:cond hooks.linter/forms)
+                           (fn [sym] (list sym '(use-state 0) 'expr)))]
+      (is (zero? (count errors)))))
+  (testing "hook at second+ test position should error"
+    (let [[exprs errors] (lint-syms
+                           (:cond hooks.linter/forms)
+                           (fn [sym] (list sym 'test 'expr '(use-state 0) 'expr)))]
+      (is (= exprs errors))))
+  (testing "hook at expr position should error"
+    (let [[exprs errors] (lint-syms
+                           (:cond hooks.linter/forms)
+                           (fn [sym] (list sym 'test '(use-state 0))))]
+      (is (= exprs errors)))))
+
+(deftest test-lint-cond-threaded
+  (testing "hook at expr position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:cond-threaded hooks.linter/forms)
+                           (fn [sym] (list sym '(use-state 0) 'test 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at test position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:cond-threaded hooks.linter/forms)
+                           (fn [sym] (list sym 'expr '(use-state 0) 'form '(use-state 0) 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at form position should error"
+    (let [[exprs errors] (lint-syms
+                           (:cond-threaded hooks.linter/forms)
+                           (fn [sym] (list sym 'expr 'test '(use-state 0))))]
+      (is (= exprs errors)))))
+
+(deftest test-lint-some-threaded
+  (testing "hook at expr position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:some-threaded hooks.linter/forms)
+                           (fn [sym] (list sym '(use-state 0) 'form 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at the first form position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:some-threaded hooks.linter/forms)
+                           (fn [sym] (list sym 'expr '(use-state 0) 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at second+ form position should error"
+    (let [[exprs errors] (lint-syms
+                           (:some-threaded hooks.linter/forms)
+                           (fn [sym] (list sym 'expr 'form '(use-state 0))))]
+      (is (= exprs errors)))))
+
+(deftest test-lint-condp
+  (testing "hook at predicate position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:condp hooks.linter/forms)
+                           (fn [sym] (list sym '(use-state 0) 'expr 'test 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at expr position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:condp hooks.linter/forms)
+                           (fn [sym] (list sym 'pred '(use-state 0) 'test 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at the first test position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:condp hooks.linter/forms)
+                           (fn [sym] (list sym 'pred 'expr '(use-state 0) 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at second+ test position should error"
+    (let [[exprs errors] (lint-syms
+                           (:condp hooks.linter/forms)
+                           (fn [sym] (list sym 'pred 'expr 'test 'form '(use-state 0) 'form)))]
+      (is (= exprs errors))))
+  (testing "hook at form position should error"
+    (let [[exprs errors] (lint-syms
+                           (:condp hooks.linter/forms)
+                           (fn [sym] (list sym 'pred 'expr 'test '(use-state 0))))]
+      (is (= exprs errors)))))
+
+(deftest test-lint-case
+  (testing "hook at expr position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:case hooks.linter/forms)
+                           (fn [sym] (list sym '(use-state 0) 'test 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at the first test position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:case hooks.linter/forms)
+                           (fn [sym] (list sym 'expr '(use-state 0) 'form)))]
+      (is (zero? (count errors)))))
+  (testing "hook at second+ test position should error"
+    (let [[exprs errors] (lint-syms
+                           (:case hooks.linter/forms)
+                           (fn [sym] (list sym 'expr 'test 'form '(use-state 0) 'form)))]
+      (is (= exprs errors))))
+  (testing "hook at form position should error"
+    (let [[exprs errors] (lint-syms
+                           (:case hooks.linter/forms)
+                           (fn [sym] (list sym 'expr 'test '(use-state 0))))]
+      (is (= exprs errors)))))
+
+(deftest test-lint-loop
+  (testing "hook at body position should error"
+    (let [[exprs errors] (lint-syms
+                           (:loop hooks.linter/forms)
+                           (fn [sym] '(loop []
+                                        (use-state 0))))]
+      (is (= exprs errors))))
+  (testing "hook at bindings position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:loop hooks.linter/forms)
+                           (fn [sym] '(loop [[x & xs] (use-state 0)])))]
+      (is (zero? (count errors))))))
+
+(deftest test-lint-for-doseq
+  (testing "hook at body position should error"
+    (let [[exprs errors] (lint-syms
+                           (:for hooks.linter/forms)
+                           (fn [sym] (list sym '[x xs]
+                                       '(use-state 0))))]
+      (is (= exprs errors))))
+  (testing "hook at the first bindings position should not error"
+    (let [[exprs errors] (lint-syms
+                           (:for hooks.linter/forms)
+                           (fn [sym] (list sym '[x (use-state 0)])))]
+      (is (zero? (count errors)))))
+  (testing "hook at second+ bindings position should error"
+    (let [[exprs errors] (lint-syms
+                           (:for hooks.linter/forms)
+                           (fn [sym] (list sym '[x (use-state 0)
+                                                 y (use-state 0)])))]
+      (is (= exprs errors))))
+  (testing "hook at modifier position should error"
+    (let [[exprs errors] (lint-syms
+                           (:for hooks.linter/forms)
+                           (fn [sym] (list sym '[x (use-state 0)
+                                                 :let [y (use-state 0)]])))]
+      (is (= exprs errors)))))
+
+(deftest test-lint-iterfn
+  (let [syms (:iter-fn hooks.linter/forms)]
+    (testing "hook at coll position should not error"
+      (let [[exprs errors] (lint-syms syms (fn [sym] (list sym identity '(use-state 0))))]
+        (is (zero? (count errors)))))
+    (testing "hook at anonymous f position should error"
+      (let [[exprs errors] (lint-syms syms (fn [sym] (list sym '(fn [x] (use-state x)) 'coll)))]
+        (is (= exprs errors))))
+    (testing "hook at anonymous f shorthand position should error"
+      (let [[exprs errors] (lint-syms syms (fn [sym] (list sym '#(use-state %) 'coll)))]
+        (is (= exprs errors))))))

--- a/core/test/uix/test_runner.clj
+++ b/core/test/uix/test_runner.clj
@@ -1,9 +1,11 @@
 (ns uix.test-runner
   (:require [clojure.test :refer :all]
             [uix.core-test]
-            [uix.aot-test]))
+            [uix.aot-test]
+            [uix.hooks.linter-test]))
 
 (defn -main [& args]
   (run-tests
     'uix.core-test
-    'uix.aot-test))
+    'uix.aot-test
+    'uix.hooks.linter-test))


### PR DESCRIPTION
This PR adds compile time check for to make sure that the rules of hooks a met in UIx components. `defui` macro checks if hooks are used within branches (`when`, `if`, `cond`, etc.) or in loops (`loop`, `map`, `filter`, etc.)

When detected, the error will be printed to terminal and appear in heads up display in a browser
<img width="1020" alt="Screenshot 2022-04-18 at 3 26 53 PM" src="https://user-images.githubusercontent.com/1355501/163810141-a62efe00-d50c-4fe7-b2e8-31584e110f75.png">
