### PR TITLE
Add exhaustive deps compile time check

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -78,14 +78,16 @@
 
 (defn- make-hook-with-deps [sym env form f deps]
   (hooks.linter/lint-exhaustive-deps! env form f deps)
-  `(~sym ~f ~(vector->js-array deps)))
+  (if deps
+    `(~sym ~f ~(vector->js-array deps))
+    `(~sym ~f)))
 
 (defmacro use-effect
   "Takes a function to be executed in an effect and optional vector of dependencies.
 
   See: https://reactjs.org/docs/hooks-reference.html#useeffect"
   ([f]
-   `(use-effect f nil))
+   (make-hook-with-deps 'uix.hooks.alpha/use-effect &env &form f nil))
   ([f deps]
    (make-hook-with-deps 'uix.hooks.alpha/use-effect &env &form f deps)))
 
@@ -93,8 +95,8 @@
   "Takes a function to be executed in a layout effect and optional vector of dependencies.
 
   See: https://reactjs.org/docs/hooks-reference.html#uselayouteffect"
-  ([setup-fn]
-   `(use-layout-effect setup-fn nil))
+  ([f]
+   (make-hook-with-deps 'uix.hooks.alpha/use-layout-effect &env &form f nil))
   ([f deps]
    (make-hook-with-deps 'uix.hooks.alpha/use-layout-effect &env &form f deps)))
 
@@ -103,7 +105,7 @@
 
    See: https://reactjs.org/docs/hooks-reference.html#usememo"
   ([f]
-   `(use-memo f nil))
+   (make-hook-with-deps 'uix.hooks.alpha/use-memo &env &form f nil))
   ([f deps]
    (make-hook-with-deps 'uix.hooks.alpha/use-memo &env &form f deps)))
 
@@ -112,7 +114,7 @@
 
   See: https://reactjs.org/docs/hooks-reference.html#usecallback"
   ([f]
-   `(use-callback f nil))
+   (make-hook-with-deps 'uix.hooks.alpha/use-callback &env &form f nil))
   ([f deps]
    (make-hook-with-deps 'uix.hooks.alpha/use-callback &env &form f deps)))
 
@@ -121,7 +123,8 @@
 
   See: https://reactjs.org/docs/hooks-reference.html#useimperativehandle"
   ([ref f]
-   `(use-imperative-handle ref f nil))
+   (hooks.linter/lint-exhaustive-deps! &env &form f nil)
+   `(uix.hooks.alpha/use-imperative-handle ~ref ~f))
   ([ref f deps]
    (hooks.linter/lint-exhaustive-deps! &env &form f deps)
    `(uix.hooks.alpha/use-imperative-handle ~ref ~f ~(vector->js-array deps))))

--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -68,3 +68,60 @@
    (uix.compiler.aot/compile-element [tag]))
   ([tag props & children]
    (uix.compiler.aot/compile-element (into [tag props] children))))
+
+;; === Hooks ===
+
+(defn vector->js-array [coll]
+  (if (vector? coll)
+    `(cljs.core/array ~@coll)
+    coll))
+
+(defn- make-hook-with-deps [sym env form f deps]
+  (hooks.linter/lint-exhaustive-deps! env form f deps)
+  `(~sym ~f ~(vector->js-array deps)))
+
+(defmacro use-effect
+  "Takes a function to be executed in an effect and optional vector of dependencies.
+
+  See: https://reactjs.org/docs/hooks-reference.html#useeffect"
+  ([f]
+   `(use-effect f nil))
+  ([f deps]
+   (make-hook-with-deps 'uix.hooks.alpha/use-effect &env &form f deps)))
+
+(defmacro use-layout-effect
+  "Takes a function to be executed in a layout effect and optional vector of dependencies.
+
+  See: https://reactjs.org/docs/hooks-reference.html#uselayouteffect"
+  ([setup-fn]
+   `(use-layout-effect setup-fn nil))
+  ([f deps]
+   (make-hook-with-deps 'uix.hooks.alpha/use-layout-effect &env &form f deps)))
+
+(defmacro use-memo
+  "Takes function f and optional vector of dependencies, and returns memoized result of f.
+
+   See: https://reactjs.org/docs/hooks-reference.html#usememo"
+  ([f]
+   `(use-memo f nil))
+  ([f deps]
+   (make-hook-with-deps 'uix.hooks.alpha/use-memo &env &form f deps)))
+
+(defmacro use-callback
+  "Takes function f and optional vector of dependencies, and returns memoized f.
+
+  See: https://reactjs.org/docs/hooks-reference.html#usecallback"
+  ([f]
+   `(use-callback f nil))
+  ([f deps]
+   (make-hook-with-deps 'uix.hooks.alpha/use-callback &env &form f deps)))
+
+(defmacro use-imperative-handle
+  "Customizes the instance value that is exposed to parent components when using ref.
+
+  See: https://reactjs.org/docs/hooks-reference.html#useimperativehandle"
+  ([ref f]
+   `(use-imperative-handle ref f nil))
+  ([ref f deps]
+   (hooks.linter/lint-exhaustive-deps! &env &form f deps)
+   `(uix.hooks.alpha/use-imperative-handle ~ref ~f ~(vector->js-array deps))))

--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -94,44 +94,12 @@
   [value]
   (hooks/use-state value))
 
-(defn use-effect
-  "Takes a function to be executed in an effect and optional vector of dependencies.
-
-  See: https://reactjs.org/docs/hooks-reference.html#useeffect"
-  ([setup-fn]
-   (hooks/use-effect setup-fn))
-  ([setup-fn deps]
-   (hooks/use-effect setup-fn deps)))
-
-(defn use-layout-effect
-  "Takes a function to be executed in a layout effect and optional vector of dependencies.
-
-  See: https://reactjs.org/docs/hooks-reference.html#uselayouteffect"
-  ([setup-fn]
-   (hooks/use-layout-effect setup-fn))
-  ([setup-fn deps]
-   (hooks/use-layout-effect setup-fn deps)))
-
-(defn use-memo
-  "Takes function f and optional vector of dependencies, and returns memoized f."
-  ([f]
-   (hooks/use-memo f))
-  ([f deps]
-   (hooks/use-memo f deps)))
-
 (defn use-ref
   "Takes optional initial value and returns React's ref hook wrapped in atom-like type."
   ([]
    (hooks/use-ref nil))
   ([value]
    (hooks/use-ref value)))
-
-(defn use-callback
-  "Takes function f and optional vector of dependencies, and returns f."
-  ([f]
-   (hooks/use-callback f))
-  ([f deps]
-   (hooks/use-callback f deps)))
 
 (defn create-context [v]
   (react/createContext v))

--- a/core/src/uix/hooks/alpha.cljs
+++ b/core/src/uix/hooks/alpha.cljs
@@ -55,8 +55,11 @@
   (r/useContext v))
 
 ;; == Imperative Handle hook ==
-(defn use-imperative-handle [ref create-handle deps]
-  (r/useImperativeHandle ref create-handle deps))
+(defn use-imperative-handle
+  ([ref create-handle]
+   (r/useImperativeHandle ref create-handle))
+  ([ref create-handle deps]
+   (r/useImperativeHandle ref create-handle deps)))
 
 ;; == Debug hook ==
 (defn use-debug

--- a/core/src/uix/hooks/linter.clj
+++ b/core/src/uix/hooks/linter.clj
@@ -1,7 +1,10 @@
 (ns uix.hooks.linter
   (:require [clojure.walk]
-            [clojure.pprint :as pp]
-            [cljs.analyzer :as ana]))
+            [cljs.analyzer :as ana]
+            [clojure.string :as str])
+  (:import (cljs.tagged_literals JSValue)))
+
+;; === Rules of Hooks ===
 
 (def ^:dynamic *component-context* nil)
 (def ^:dynamic *in-branch?* false)
@@ -152,3 +155,81 @@
                                               %))
             errors))))
 
+;; === Exhaustive Deps ===
+
+(defn find-free-variables [env f deps]
+  (let [syms (atom #{})
+        deps (set deps)]
+    (clojure.walk/postwalk
+      #(cond
+         (symbol? %)
+         (do (swap! syms conj %)
+             %)
+
+         (= (type %) JSValue)
+         (.-val %)
+
+         :else %)
+      f)
+    (keep #(let [local (get-in env [:locals % :name])]
+             (when (and local (nil? (deps local)))
+               local))
+          @syms)))
+
+(defmethod ana/error-message ::inline-function [_ {:keys [source]}]
+  (str "React Hook " source " received a function whose dependencies "
+       "are unknown. Pass an inline function instead."))
+
+(defmethod ana/error-message ::missing-deps [_ {:keys [source syms deps]}]
+  (str "React Hook " source " has missing dependencies: [" (str/join " " syms) "]. "
+       "Update the dependencies vector to be: [" (str/join " " (concat deps syms)) "]"))
+
+(defmethod ana/error-message ::deps-array-literal [_ {:keys [source]}]
+  (str "React Hook " source " was passed a "
+       "dependency list that is a JavaScript array, instead of Clojure’s vector. "
+       "Change it to be a vector literal."))
+
+(defmethod ana/error-message ::deps-coll-literal [_ {:keys [source]}]
+  (str "React Hook " source " was passed a "
+       "dependency list that is not a vector literal. This means we "
+       "can’t statically verify whether you've passed the correct dependencies. "
+       "Change it to be a vector literal with explicit set of dependencies."))
+
+(defmethod ana/error-message ::literal-value-in-deps [_ {:keys [source literals]}]
+  (str "React Hook " source " was passed literal values in dependency vector: [" (str/join ", " literals) "]. "
+       "Those are not valid dependencies because they never change. You can safely remove them."))
+
+(defn- fn-literal? [form]
+  (and (list? form) ('#{fn fn*} (first form))))
+
+(def literal?
+  (some-fn keyword? number? string? nil? boolean?))
+
+(defn- deps->literals [deps]
+  (filter literal? deps))
+
+(defn lint-exhaustive-deps! [env form f deps]
+  (when deps
+    (cond
+      ;; when deps are passed as JS Array, should be a vector instead
+      (and (= (type deps) JSValue) (vector? (.-val deps)))
+      (ana/warning ::deps-array-literal env {:source form})
+
+      ;; when deps are neither JS Array nor Clojure's vector, should be a vector instead
+      (not (vector? deps))
+      (ana/warning ::deps-coll-literal env {:source form})
+
+      ;; when deps vector has a primitive literal, it can be safely removed
+      (seq (deps->literals deps))
+      (ana/warning ::literal-value-in-deps env {:source form :literals (deps->literals deps)})))
+
+  (cond
+    ;; when a reference to a function passed into a hook, should be an inline function instead
+    (not (fn-literal? f))
+    (ana/warning ::inline-function env {:source form})
+
+    (vector? deps)
+    (let [syms (find-free-variables env f deps)]
+      ;; when hook function is referencing vars from out scope that are missing in deps vector
+      (when (seq syms)
+        (ana/warning ::missing-deps env {:syms syms :deps deps :source form})))))

--- a/core/test/uix/core_test.clj
+++ b/core/test/uix/core_test.clj
@@ -1,7 +1,9 @@
 (ns uix.core-test
   (:require [clojure.test :refer :all]
             [uix.core]
-            [uix.core.lazy-loader :refer [require-lazy]]))
+            [uix.core.lazy-loader :refer [require-lazy]]
+            [cljs.analyzer :as ana])
+  (:import (cljs.tagged_literals JSValue)))
 
 (require-lazy '[clojure.string :refer [blank?]])
 
@@ -28,3 +30,40 @@
          '(uix.compiler.aot/>el identity (cljs.core/array (cljs.core/js-obj)) (cljs.core/array 1 2))))
   (is (= (macroexpand-1 '(uix.core/$ :> identity {:x 1 :ref 2} 1 2))
          '(uix.compiler.aot/>el identity (cljs.core/array (js* "{'x':~{},'ref':~{}}" 1 2)) (cljs.core/array 1 2)))))
+
+(defn test-linter [form expected-messages]
+  (let [errors (atom [])
+        _ (with-redefs [ana/warning #(swap! errors conj %&)]
+            (macroexpand-1 form))
+        actual-messages (map (fn [[warning-type _ extra]]
+                               (ana/error-message warning-type extra))
+                             @errors)]
+    (is (= actual-messages expected-messages))))
+
+(deftest test-hooks
+  (test-linter
+    '(uix.core/use-effect identity)
+    [(str "React Hook (uix.core/use-effect identity) received a function whose dependencies are unknown. "
+          "Pass an inline function instead.")])
+  (test-linter
+    '(uix.core/use-effect identity [])
+    [(str "React Hook (uix.core/use-effect identity []) received "
+          "a function whose dependencies are unknown. Pass an inline function instead.")])
+  (let [form `(uix.core/use-effect ~'(fn []) ~(JSValue. []))]
+    (test-linter
+      form
+      [(str "React Hook " form
+            " was passed a dependency list that is a JavaScript array, "
+            "instead of Clojure’s vector. Change it to be a vector literal.")]))
+  (test-linter
+    `(uix.core/use-effect ~'(fn []) ~'coll)
+    [(str "React Hook (uix.core/use-effect (fn []) coll) was passed a dependency list "
+          "that is not a vector literal. This means we can’t statically verify whether "
+          "you've passed the correct dependencies. Change it to be a vector literal "
+          "with explicit set of dependencies.")])
+  (test-linter
+    `(uix.core/use-effect ~'(fn []) [:kw])
+    [(str "React Hook (uix.core/use-effect (fn []) [:kw]) was passed literal values "
+          "in dependency vector: [:kw]. Those are not valid dependencies because "
+          "they never change. You can safely remove them.")]))
+  ;; TODO: missing deps)


### PR DESCRIPTION
This PR adds checks similar to React's ESLint plugin for "exhaustive deps". In this PR all core deps-based hooks were turned into macros that take deps list as a vector and the following checks are performed:

1. When a function reference is passed into a hook
```clojure
;; React Hook (use-effect f) received a function whose dependencies are unknown.
;; Pass an inline function instead.
(use-effect f)
```

2. When deps are passed as JS array
```clojure
;; React Hook (use-effect #(...) #js [x y]) was passed a dependency list
;; that is a JavaScript array, instead of Clojure’s vector. 
;; Change it to be a vector literal.
(use-effect #(...) #js [x y])
```

3. When neither js array nor vector is passed as deps
```clojure
;; React Hook (use-effect #(...) coll) was passed a dependency list
;; that is not a vector literal. This means we can’t statically verify whether you've passed the correct dependencies. 
;; Change it to be a vector literal with explicit set of dependencies.
(use-effect #(...) coll)
```

4. When a vector of deps includes a literal of a primitive type
```clojure
;; React Hook (use-effect #(...) [1 nil false :kw "string"]) was passed literal values
;; in dependency vector: [1 nil false :kw "string"].
;; Those are not valid dependencies because they never change. You can safely remove them.
(use-effect #(...) [1 nil false :kw "string" 'sym])
```

5. When hook body is using deps that are not declared in deps vector
```clojure
;; React Hook " source " has missing dependencies: [x]
;; Update the dependencies vector to be: [x]
(use-effect #(prn x) [])
```

I'll be adding more checks later