### PR TITLE
track current uix component

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -5,15 +5,22 @@
             [cljs.core]
             [uix.hooks.linter :as hooks.linter]))
 
+(def ^:private goog-debug (with-meta 'goog.DEBUG {:tag 'boolean}))
+
 (defn- no-args-component [sym body]
   `(defn ~sym []
-     ~@body))
+     (let [f# (fn [] ~@body)]
+       (if ~goog-debug
+         (binding [*current-component* ~sym] (f#))
+         (f#)))))
 
 (defn- with-args-component [sym args body]
   `(defn ~sym [props#]
      (let [~args (cljs.core/array (glue-args props#))
            f# (fn [] ~@body)]
-       (f#))))
+       (if ~goog-debug
+         (binding [*current-component* ~sym] (f#))
+         (f#)))))
 
 (defn parse-sig [name fdecl]
   (let [[fdecl m] (if (string? (first fdecl))

--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -8,6 +8,8 @@
             [uix.compiler.aot]
             [uix.lib :refer [doseq-loop]]))
 
+(def ^:dynamic *current-component*)
+
 ;; React's top-level API
 
 (defn create-class


### PR DESCRIPTION
Tracking UIx components being currently executed for dev-time checks. Currently added to make sure that re-frame subscriptions are not used in UIx components via Reagent API.