### PR TITLE
check for unnecessary deps & set-state in effect w/o deps

### DIFF
--- a/core/test/uix/core_test.clj
+++ b/core/test/uix/core_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [uix.core]
             [uix.core.lazy-loader :refer [require-lazy]]
-            [cljs.analyzer :as ana])
+            [cljs.analyzer :as ana]
+            [uix.hooks.linter :as linter])
   (:import (cljs.tagged_literals JSValue)))
 
 (require-lazy '[clojure.string :refer [blank?]])
@@ -43,27 +44,22 @@
 (deftest test-hooks
   (test-linter
     '(uix.core/use-effect identity)
-    [(str "React Hook (uix.core/use-effect identity) received a function whose dependencies are unknown. "
-          "Pass an inline function instead.")])
+    ["React Hook received a function whose dependencies are unknown. Pass an inline function instead.\n```\n(uix.core/use-effect identity)\n```"])
   (test-linter
     '(uix.core/use-effect identity [])
-    [(str "React Hook (uix.core/use-effect identity []) received "
-          "a function whose dependencies are unknown. Pass an inline function instead.")])
+    ["React Hook received a function whose dependencies are unknown. Pass an inline function instead.\n```\n(uix.core/use-effect identity [])\n```"])
   (let [form `(uix.core/use-effect ~'(fn []) ~(JSValue. []))]
     (test-linter
       form
-      [(str "React Hook " form
-            " was passed a dependency list that is a JavaScript array, "
-            "instead of Clojure’s vector. Change it to be a vector literal.")]))
+      [(str "React Hook was passed a dependency list that is a JavaScript array, instead of Clojure’s vector. Change it to be a vector literal.\n"
+            (linter/ppr form))]))
   (test-linter
     `(uix.core/use-effect ~'(fn []) ~'coll)
-    [(str "React Hook (uix.core/use-effect (fn []) coll) was passed a dependency list "
-          "that is not a vector literal. This means we can’t statically verify whether "
-          "you've passed the correct dependencies. Change it to be a vector literal "
-          "with explicit set of dependencies.")])
+    [(str "React Hook was passed a dependency list that is not a vector literal. This means we can’t statically verify whether you've passed the correct dependencies. Change it to be a vector literal with explicit set of dependencies.\n"
+          (linter/ppr '(uix.core/use-effect (fn []) coll)))])
   (test-linter
     `(uix.core/use-effect ~'(fn []) [:kw])
-    [(str "React Hook (uix.core/use-effect (fn []) [:kw]) was passed literal values "
-          "in dependency vector: [:kw]. Those are not valid dependencies because "
-          "they never change. You can safely remove them.")]))
-  ;; TODO: missing deps)
+    [(str "React Hook was passed literal values in dependency vector: [:kw]\nThose are not valid dependencies because they never change. You can safely remove them.\n"
+          (linter/ppr '(uix.core/use-effect (fn []) [:kw])))]))
+  ;; TODO: missing & unnecessary deps
+  ;; TODO: set-state w/o deps


### PR DESCRIPTION
Extending the linter to check and report on unnecessary deps in a hook, those are:
- React ref, created with `use-ref`, [see for more info on that](https://epicreact.dev/why-you-shouldnt-put-refs-in-a-dependency-array/)
- state updater function, from either `use-state` or `use-reducer`, the function is memoized, thus doesn't change

and report on usage of a state updater function from either `use-state` or `use-reducer` in a hook w/o deps vector, which will lead to an infinite loop of updates