### PR TITLE
Support for multi-level tags

### DIFF
--- a/core/src/uix/compiler/attributes.clj
+++ b/core/src/uix/compiler/attributes.clj
@@ -31,15 +31,15 @@
     (let [props-class (get props :class)]
       (cond-> props
               ;; Only use ID from tag keyword if no :id in props already
-        (and (some? id) (nil? (get props :id)))
-        (assoc :id id)
+              (and (some? id) (nil? (get props :id)))
+              (assoc :id id)
 
               ;; Merge classes
-        (or class props-class)
-        (assoc :class (cond
-                        (vector? props-class) `(class-names ~class ~@props-class)
-                        props-class `(class-names ~class ~props-class)
-                        :else class))))
+              (or class props-class)
+              (assoc :class (cond
+                              (vector? props-class) `(class-names ~class ~@props-class)
+                              props-class `(class-names ~class ~props-class)
+                              :else class))))
     props))
 
 (defn camel-case

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -32,3 +32,18 @@
          '(uix.compiler.aot/>el x (cljs.core/array (cljs.core/js-obj)) (cljs.core/array 1 2))))
   (is (= (aot/compile-element '[:> x {:x 1 :ref 2} 1 2])
          '(uix.compiler.aot/>el x (cljs.core/array (js* "{'x':~{},'ref':~{}}" 1 2)) (cljs.core/array 1 2)))))
+
+(deftest test-compile-tree
+  (is (= (aot/compile-element [:div])
+         '(uix.compiler.aot/>el "div" (cljs.core/array nil) (cljs.core/array))))
+  (is (= (aot/compile-element [:div#foo>div.bar>div#baz {} "What a lovely tag!"])
+         '(uix.compiler.aot/>el
+           "div"
+           (cljs.core/array (js* "{'id':~{}}" "foo"))
+           (cljs.core/array (uix.compiler.aot/>el
+                             "div"
+                             (cljs.core/array (js* "{'className':~{}}" "bar"))
+                             (cljs.core/array (uix.compiler.aot/>el
+                                               "div"
+                                               (cljs.core/array (js* "{'id':~{}}" "baz"))
+                                               (cljs.core/array "What a lovely tag!")))))))))

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -9,6 +9,13 @@
   (is (= (attrs/parse-tag (name :custom-tag))
          ["custom-tag" nil nil true])))
 
+(deftest test-parse-tags
+  (is (= (attrs/parse-tags :div#id.class)
+         '(["div" "id" "class" false])))
+  (is (= (attrs/parse-tags :div#id.class>h1)
+         '(["div" "id" "class" false]
+           ["h1" nil nil false]))))
+
 (deftest test-class-names
   (is (= (attrs/compile-config-kv :class nil) nil))
   (testing "Named types"

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -43,8 +43,6 @@
                       (.-stack e)))]
         (is (str/includes? stack "uix.compiler-test/some-component"))))))
 
-
-
 (uix.core/defui to-string-test-comp [props]
   ($ :div {} (str "i am " (:foo props))))
 
@@ -126,7 +124,6 @@
 
 (deftest test-keys
   (with-error #(as-string ($ key-tester))))
-
 
 (deftest style-property-names-are-camel-cased
   (is (re-find #"<div style=\"text-align:center(;?)\">foo</div>"
@@ -219,6 +216,12 @@
   (when ^boolean goog.DEBUG
     (uix.core/defui test-comp [] "x")
     (is (= test-comp (.-type ($ test-comp))))))
+
+(deftest test-multilevel-tags
+  (is (= (as-string ($ :div>h1 {} "Heading"))
+         "<div><h1>Heading</h1></div>"))
+  (is (= (as-string ($ :div#foo.bar>h1#baz.bob {} "Heading"))
+         "<div id=\"foo\" class=\"bar\"><h1 id=\"baz\" class=\"bob\">Heading</h1></div>")))
 
 (defn -main []
   (run-tests))


### PR DESCRIPTION
An admittedly rarely used, but nice, feature of the Reagent Hiccup syntax was being able to denote a few tags in one go. It can reduce verbosity. Example:

`($ :div#a>h1.b)`

Gives:

 `<div id=\"a\"><h1 class=\"b\"></h1></div>`
