### PR TITLE
stringify keyword, symbol and uuid  types in deps

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -80,8 +80,8 @@
 
 (defn vector->js-array [coll]
   (cond
-    (vector? coll) `(cljs.core/array ~@coll)
-    (some? coll) `(cljs.core/into-array ~coll)
+    (vector? coll) `(jsfy-deps (cljs.core/array ~@coll))
+    (some? coll) `(jsfy-deps ~coll)
     :else coll))
 
 (defn- make-hook-with-deps [sym env form f deps]

--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -160,6 +160,7 @@
     ;; fast direct lookup for a string value
     ;; already stored on the instance of the known type
     (keyword? v) (.-fqn v)
+    (uuid? v) (.-uuid v)
     (symbol? v) (.-str v)
     :else v))
 

--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -154,3 +154,21 @@
   "Interop with React components. Takes UIx component function and returns same component wrapped into interop layer."
   [f]
   (compiler/as-react f))
+
+(defn stringify-clojure-primitives [v]
+  (cond
+    ;; fast direct lookup for a string value
+    ;; already stored on the instance of the known type
+    (keyword? v) (.-fqn v)
+    (symbol? v) (.-str v)
+    :else v))
+
+(defn jsfy-deps [coll]
+  (if (or (js/Array.isArray coll)
+          (vector? coll))
+    (reduce (fn [arr v]
+              (.push arr (stringify-clojure-primitives v))
+              arr)
+            #js []
+            coll)
+    coll))

--- a/core/test/uix/core_test.clj
+++ b/core/test/uix/core_test.clj
@@ -25,8 +25,8 @@
         (uix.core/parse-sig 'component-name '([props x])))))
 
 (deftest test-vector->js-array
-  (is (= '(cljs.core/array 1 2 3) (uix.core/vector->js-array [1 2 3])))
-  (is (= '(cljs.core/into-array x) (uix.core/vector->js-array 'x)))
+  (is (= '(uix.core/jsfy-deps (cljs.core/array 1 2 3)) (uix.core/vector->js-array [1 2 3])))
+  (is (= '(uix.core/jsfy-deps x) (uix.core/vector->js-array 'x)))
   (is (nil? (uix.core/vector->js-array nil))))
 
 (deftest test-$

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -103,10 +103,10 @@
         (t/render ($ err-b {:done done :x 1 :child child})))))
 
 (deftest test-jsfy-deps
-  (is (= [1 "str" "k/w" "uix.core/sym" nil [] {} #{}]
-         (vec (uix.core/jsfy-deps [1 "str" :k/w 'uix.core/sym nil [] {} #{}]))))
-  (is (= [1 "str" "k/w" "uix.core/sym" nil [] {} #{}]
-         (vec (uix.core/jsfy-deps #js [1 "str" :k/w 'uix.core/sym nil [] {} #{}]))))
+  (is (= [1 "str" "k/w" "uix.core/sym" "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]
+         (vec (uix.core/jsfy-deps [1 "str" :k/w 'uix.core/sym #uuid "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]))))
+  (is (= [1 "str" "k/w" "uix.core/sym" "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]
+         (vec (uix.core/jsfy-deps #js [1 "str" :k/w 'uix.core/sym #uuid "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]))))
   (is (= #{} (uix.core/jsfy-deps #{})))
   (is (= {} (uix.core/jsfy-deps {}))))
 

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -102,5 +102,13 @@
       (async done
         (t/render ($ err-b {:done done :x 1 :child child})))))
 
+(deftest test-jsfy-deps
+  (is (= [1 "str" "k/w" "uix.core/sym" nil [] {} #{}]
+         (vec (uix.core/jsfy-deps [1 "str" :k/w 'uix.core/sym nil [] {} #{}]))))
+  (is (= [1 "str" "k/w" "uix.core/sym" nil [] {} #{}]
+         (vec (uix.core/jsfy-deps #js [1 "str" :k/w 'uix.core/sym nil [] {} #{}]))))
+  (is (= #{} (uix.core/jsfy-deps #{})))
+  (is (= {} (uix.core/jsfy-deps {}))))
+
 (defn -main []
   (run-tests))


### PR DESCRIPTION
Stringifying symbol, keyword and uuid types, since they are primitives in Clojure, but ref types in JS, thus following referential equality in Hooks deps