### PR TITLE
[exploration] add runtime & compile time spec checks for props

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -1,6 +1,5 @@
 (ns uix.compiler.alpha
   (:require [react :as react]
-            [uix.hooks.alpha :as hooks]
             [cljs-bean.core :as bean]
             [uix.compiler.debug :as debug]))
 

--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -59,13 +59,12 @@
         [fdecl props-spec] (hooks.linter/make-props-check &env sym fdecl)]
     (uix.source/register-symbol! sym)
     (hooks.linter/lint! sym fdecl &env)
-    (let []
-      `(do
-         ~(if (empty? args)
-            (no-args-component fname fdecl)
-            (with-args-component fname args fdecl props-spec))
-         (set! (.-uix-component? ~(with-meta sym {:tag 'js})) true)
-         (with-name ~sym ~(-> &env :ns :name str) ~(str sym))))))
+    `(do
+       ~(if (empty? args)
+          (no-args-component fname fdecl)
+          (with-args-component fname args fdecl props-spec))
+       (set! (.-uix-component? ~(with-meta sym {:tag 'js})) true)
+       (with-name ~sym ~(-> &env :ns :name str) ~(str sym)))))
 
 (defmacro source
   "Returns source string of UIx component"

--- a/core/src/uix/hooks/linter.clj
+++ b/core/src/uix/hooks/linter.clj
@@ -401,8 +401,8 @@
 (def ^:private props-specs-registry (atom {}))
 
 (defn register-props-spec!
-  "Associates :props spec to a component name
-  The spec is used check provided props at component usage place ($ ...)"
+  "Associates component name with provided :props spec
+  The spec is used to check provided props at component usage place ($ ...)"
   [env component-sym props-spec]
   (let [sym (uix.lib/ns-qualify env component-sym)]
     (swap! props-specs-registry assoc sym props-spec)))

--- a/core/src/uix/hooks/linter.clj
+++ b/core/src/uix/hooks/linter.clj
@@ -413,17 +413,20 @@
        (concat (get spec q-key))
        set))
 
+(defn- parse-keys-spec-form [spec-form]
+  (->> (rest spec-form)
+       (partition 2)
+       (reduce (fn [ret [k v]]
+                 (assoc ret k v))
+               {})))
+
 (defn assert-props-spec*
   "Asserts provided `props` and `children` against `spec-form` registered for a given `component-name`"
   [env spec-form component-name props children]
   (when (= 'cljs.spec.alpha/keys (first spec-form))
-    (let [spec (->> (rest spec-form)
-                    (partition 2)
-                    (reduce (fn [ret [k v]]
-                              (assoc ret k v))
-                            {}))
-          req-ks (get-spec-keys :req-un :req spec)
-          opt-ks (get-spec-keys :opt-un :opt spec)
+    (let [spec-map (parse-keys-spec-form spec-form)
+          req-ks (get-spec-keys :req-un :req spec-map)
+          opt-ks (get-spec-keys :opt-un :opt spec-map)
           spec-ks (into req-ks opt-ks)]
       (if (and (not (map? props)) (not= #{:children} req-ks))
         ;; expected some props, but got a non map literal value instead

--- a/core/src/uix/lib.cljc
+++ b/core/src/uix/lib.cljc
@@ -1,5 +1,6 @@
 (ns uix.lib
-  #?(:cljs (:require-macros [uix.lib :refer [doseq-loop]])))
+  #?(:cljs (:require-macros [uix.lib :refer [doseq-loop]]))
+  #?(:clj (:require [cljs.analyzer :as ana])))
 
 #?(:clj
    (defmacro doseq-loop [[v vs] & body]
@@ -34,3 +35,20 @@
 #?(:clj
    (defn cljs-env? [env]
      (boolean (:ns env))))
+
+#?(:clj
+   (defn- ->sym
+     "Returns a symbol from a symbol or var"
+     [x]
+     (if (map? x)
+       (:name x)
+       x)))
+
+#?(:clj
+   (defn ns-qualify
+     "Qualify symbol s by resolving it or using the current *ns*."
+     [env s]
+     (if (namespace s)
+       (binding [ana/*private-var-access-nowarn* true]
+         (->sym (ana/resolve-var env s)))
+       (symbol (str ana/*cljs-ns*) (str s)))))


### PR DESCRIPTION
This PR adds runtime and compile time spec check for props in UIx components

```clojure
(s/def :event/on-click fn?)
(s/def :button/children (s/cat :text string?))
(s/def :attr/title string?)

(s/def :button/props
  (s/keys :req-un [:event/on-click :button/children]
          :opt-un [:attr/title]))

(defui button
  [{:keys [on-click title children]}]
  {:props :button/props}
  ($ :button {:on-click on-click :title title}
    children))

;; === Examples of compile time check=== 

($ button {:on-click f})
;; Missing child elements in UIx component `app.ui/button`

($ button "press me")
;; Invalid props value passed into UIx component `app.ui/button`
;; Expects a map literal with the following set of keys: #{:children :on-click}
;; But instead got `press me` as a child element

($ button {:title "play button"} "press me")
;; Missing props #{:on-click} in UIx component `app.ui/button`
;; Instead got the following set of keys: #{:children :title}
```

### Runtime spec check
At runtime, only in dev, `defui` component assert `props` map against provided `:props` spec. Nothing custom here, it can be also done in a `:pre` condition.

### Compile time check
The purpose of the compile time check is to make sure that a component is provided with what's required, not less or more data. The check is performed only for top level keys of the props map though and requires the props map to be a map literal.
This has multiple benefits:
1. Not possible to pass an obscure `props` value into child components, only explicit map literal
2. Allowing to pass in only what is expected makes sure that a component is updated only when relevant data has changed (when a component is memoized)
3. Catching missing keys at compile time means there's no way someone would miss an error even if they didn't test the change in UI

#### Why special :props condition?
For compile time check there should a well defined slot where a referenced spec can be read from.

#### Why checking only top-level keys at compile time?
Having a requirement to pass nested compound values as literals can quickly become annoying. Having looked at existing code a frequent pattern is to provide more top-level keys than required and passing through `props` value, thus a check for top-level keys only is sufficient.

#### Is it possible to check nested values in props map at runtime?
While checking at top-level will already cover most of the cases, ideally it should be possible to apply the same pattern to nested values, to make sure that a component is not "overfetching" props. Since spec is open we'll have to use a different library, maybe [`malli`](https://github.com/metosin/malli)?

#### Are :pre and :post conditions still supported?
Yes. The map with conditions can include all three: `:pre`, `:post` and `:props`.