### PR TITLE
Remove no-deps version of use-memo and use-callback

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -111,22 +111,18 @@
    (make-hook-with-deps 'uix.hooks.alpha/use-layout-effect &env &form f deps)))
 
 (defmacro use-memo
-  "Takes function f and optional vector of dependencies, and returns memoized result of f.
+  "Takes function f and required vector of dependencies, and returns memoized result of f.
 
    See: https://reactjs.org/docs/hooks-reference.html#usememo"
-  ([f]
-   (make-hook-with-deps 'uix.hooks.alpha/use-memo &env &form f nil))
-  ([f deps]
-   (make-hook-with-deps 'uix.hooks.alpha/use-memo &env &form f deps)))
+  [f deps]
+  (make-hook-with-deps 'uix.hooks.alpha/use-memo &env &form f deps))
 
 (defmacro use-callback
-  "Takes function f and optional vector of dependencies, and returns memoized f.
+  "Takes function f and required vector of dependencies, and returns memoized f.
 
   See: https://reactjs.org/docs/hooks-reference.html#usecallback"
-  ([f]
-   (make-hook-with-deps 'uix.hooks.alpha/use-callback &env &form f nil))
-  ([f deps]
-   (make-hook-with-deps 'uix.hooks.alpha/use-callback &env &form f deps)))
+  [f deps]
+  (make-hook-with-deps 'uix.hooks.alpha/use-callback &env &form f deps))
 
 (defmacro use-imperative-handle
   "Customizes the instance value that is exposed to parent components when using ref.

--- a/core/src/uix/hooks/alpha.cljs
+++ b/core/src/uix/hooks/alpha.cljs
@@ -44,17 +44,13 @@
 
 ;; == Callback hook ==
 (defn use-callback
-  ([f]
-   (r/useCallback f))
-  ([f deps]
-   (r/useCallback f deps)))
+  [f deps]
+  (r/useCallback f deps))
 
 ;; == Memo hook ==
 (defn use-memo
-  ([f]
-   (r/useMemo f))
-  ([f deps]
-   (r/useMemo f deps)))
+  [f deps]
+  (r/useMemo f deps))
 
 ;; == Context hook ==
 (defn use-context [v]


### PR DESCRIPTION
Memoization hooks (i.e. `use-memo` and `use-callback`) do not have a meaning without a dependency vector. React complains if you pass no deps on these hooks [[more](https://github.com/facebook/react/pull/15025)]. 

This PR removes the 1-arity on `use-memo` and `use-callback`.