### PR TITLE
Update unsupported CI Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs: 
+  browser-tools: circleci/browser-tools@1.3.0
   github-cli: circleci/github-cli@1.0.5
 
 jobs:
@@ -22,7 +23,7 @@ jobs:
   
   build:
     docker:
-      - image: circleci/clojure:tools-deps-1.10.0.442-node
+      - image: cimg/clojure:1.11-browsers
         command: "/bin/bash"
 
     working_directory: ~/repo
@@ -30,16 +31,8 @@ jobs:
     steps:
       - checkout
       - github-cli/setup
-      - run:
-          name: Install Headless Chrome dependencies
-          command: |
-            sudo apt-get update && \
-            sudo apt-get install -yq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
 
       - restore_cache:
           keys:


### PR DESCRIPTION
* Switched to recommended `cimg/clojure:1.11-browsers` for the `build` job
* Using `browser-tools` orb instead of inline installation of Chrome dependencies