### PR TITLE
remove :> interop syntax in favor of implicit interop with react components

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -1,6 +1,9 @@
 (ns uix.compiler.alpha
   (:require [react :as react]
-            [cljs-bean.core :as bean]))
+            [cljs-bean.core :as bean]
+            [goog.object :as gobj]
+            [uix.compiler.attributes :as attrs]
+            [clojure.string :as str]))
 
 (defn symbol-for [s]
   (js* "Symbol.for(~{})" s))
@@ -8,19 +11,22 @@
 (defn as-react [f]
   #(f #js {:argv (bean/bean %)}))
 
+(defn- reagent-component? [^js component-type]
+  (->> (.keys js/Object component-type)
+       (some #(when (str/starts-with? % "G_")
+                (identical? component-type (gobj/get component-type %))))))
+
 (defn validate-component [^js component-type]
-  (when-not ^boolean (.-uix-component? component-type)
+  (when (and (not (.-uix-component? component-type))
+             (reagent-component? component-type))
     (let [name-str (or (.-displayName component-type)
                        (.-name component-type))]
-      (throw (js/Error. (str "Invalid use of a non-UIx component " name-str " in `$` form.\n"
-                             "Make sure that the component is declared with `defui`\n"
-                             "If you meant to render React element, use :> syntax for interop with JavaScript components, i.e. ($ :> " name-str ")\n"
-                             "If you meant to render Reagent element, make it Hiccup wrapped with r/as-element, i.e. (r/as-element [" name-str "])")))))
+      (throw (js/Error. (str "Invalid use of Reagent component " name-str " in `$` form.\n"
+                             "UIx doesn't know how to render Reagent components.\n"
+                             "Reagent element should be Hiccup wrapped with r/as-element, i.e. (r/as-element [" name-str "])")))))
   true)
 
-(defn component-element [component-type ^js props-children children]
-  (when ^boolean goog.DEBUG
-    (validate-component component-type))
+(defn- uix-component-element [component-type ^js props-children children]
   (let [props (aget props-children 0)
         js-props (if-some [key (:key props)]
                    #js {:key key :argv (dissoc props :key)}
@@ -29,3 +35,19 @@
                #js [component-type js-props (aget props-children 1)]
                #js [component-type js-props])]
     (.apply react/createElement nil (.concat args children))))
+
+(defn- react-component-element [component-type ^js props-children children]
+  (let [js-props (-> (aget props-children 0)
+                     (attrs/interpret-attrs #js [] true)
+                     (aget 0))
+        args (if (= 2 (.-length props-children))
+               #js [component-type js-props (aget props-children 1)]
+               #js [component-type js-props])]
+    (.apply react/createElement nil (.concat args children))))
+
+(defn component-element [^clj component-type props-children children]
+  (when ^boolean goog.DEBUG
+    (validate-component component-type))
+  (if (.-uix-component? component-type)
+    (uix-component-element component-type props-children children)
+    (react-component-element component-type props-children children)))

--- a/core/src/uix/compiler/aot.clj
+++ b/core/src/uix/compiler/aot.clj
@@ -28,14 +28,6 @@
     `(cljs.core/array ~(-> attrs attrs/compile-attrs js/to-js))
     `(uix.compiler.attributes/interpret-attrs ~attrs (cljs.core/array) false)))
 
-(defmethod compile-attrs :interop [_ props _]
-  (if (map? props)
-    `(cljs.core/array
-      ~(cond-> props
-         :always (attrs/compile-attrs {:custom-element? true})
-         :always (js/to-js-map true)))
-    `(uix.compiler.attributes/interpret-attrs ~props (cljs.core/array) true)))
-
 (defn- input-component? [x]
   (contains? #{"input" "textarea"} x))
 
@@ -72,7 +64,6 @@
   (fn [[tag] _]
     (cond
       (= :<> tag) :fragment
-      (= :> tag) :interop
       (keyword? tag) :element
       :else :component)))
 
@@ -97,8 +88,3 @@
         attrs (compile-attrs :fragment attrs nil)
         ret `(>el fragment ~attrs (cljs.core/array ~@children))]
     ret))
-
-(defmethod compile-element :interop [v _]
-  (let [[_ tag props & children] v
-        props (compile-attrs :interop props nil)]
-    `(>el ~tag ~props (cljs.core/array ~@children))))

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -147,14 +147,15 @@
   - `id-class` — a triplet of parsed tag, id and class names
   - `shallow?` — indicates whether `props` map should be converted shallowly or not"
   [props id-class ^boolean shallow?]
-  (cond
-    ^boolean (aget id-class 3)
-    (convert-custom-prop-value (set-id-class props id-class))
+  (let [props (set-id-class props id-class)]
+    (cond
+      ^boolean (aget id-class 3)
+      (convert-custom-prop-value props)
 
-    shallow?
-    (convert-prop-value-shallow props)
+      shallow?
+      (convert-prop-value-shallow props)
 
-    :else (convert-prop-value (set-id-class props id-class))))
+      :else (convert-prop-value props))))
 
 (defn interpret-attrs
   "Returns a tuple of attributes and a child element

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -51,24 +51,12 @@
           v)))
     k))
 
-(defn convert-interop-prop-value [k v]
-  (cond
-    (= k :style) (if (vector? v)
-                   (-reduce ^not-native v
-                            (fn [a v]
-                              (.push a (convert-prop-value-shallow v))
-                              a)
-                            #js [])
-                   (convert-prop-value-shallow v))
-    (keyword? v) (-name ^not-native v)
-    :else v))
-
 (defn kv-conv [o k v]
   (gobj/set o (cached-prop-name k) (convert-prop-value v))
   o)
 
 (defn kv-conv-shallow [o k v]
-  (gobj/set o (cached-prop-name k) (convert-interop-prop-value k v))
+  (gobj/set o (cached-custom-prop-name k) v)
   o)
 
 (defn custom-kv-conv [o k v]
@@ -141,21 +129,20 @@
 
 (defn convert-props
   "Converts `props` Clojure map into JS object suitable for
-  passing as `props` object into `React.crteateElement`
+  passing as `props` object into `React.createElement`
 
   - `props` — Clojure map of props
   - `id-class` — a triplet of parsed tag, id and class names
   - `shallow?` — indicates whether `props` map should be converted shallowly or not"
   [props id-class ^boolean shallow?]
-  (let [props (set-id-class props id-class)]
-    (cond
-      ^boolean (aget id-class 3)
-      (convert-custom-prop-value props)
+  (cond
+    ^boolean (aget id-class 3)
+    (convert-custom-prop-value (set-id-class props id-class))
 
-      shallow?
-      (convert-prop-value-shallow props)
+    shallow?
+    (convert-prop-value-shallow props)
 
-      :else (convert-prop-value props))))
+    :else (convert-prop-value (set-id-class props id-class))))
 
 (defn interpret-attrs
   "Returns a tuple of attributes and a child element

--- a/core/src/uix/compiler/attributes.cljs
+++ b/core/src/uix/compiler/attributes.cljs
@@ -51,12 +51,24 @@
           v)))
     k))
 
+(defn convert-interop-prop-value [k v]
+  (cond
+    (= k :style) (if (vector? v)
+                   (-reduce ^not-native v
+                            (fn [a v]
+                              (.push a (convert-prop-value-shallow v))
+                              a)
+                            #js [])
+                   (convert-prop-value-shallow v))
+    (keyword? v) (-name ^not-native v)
+    :else v))
+
 (defn kv-conv [o k v]
   (gobj/set o (cached-prop-name k) (convert-prop-value v))
   o)
 
 (defn kv-conv-shallow [o k v]
-  (gobj/set o (cached-custom-prop-name k) v)
+  (gobj/set o (cached-prop-name k) (convert-interop-prop-value k v))
   o)
 
 (defn custom-kv-conv [o k v]

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -37,7 +37,7 @@
 (deftest test-compile-html
   (is (= (aot/compile-element [:h1] nil)
          '(uix.compiler.aot/>el "h1" (cljs.core/array nil) (cljs.core/array))))
-  (is (= (aot/compile-element '[:> x {} 1 2] nil)
-         '(uix.compiler.aot/>el x (cljs.core/array (cljs.core/js-obj)) (cljs.core/array 1 2))))
-  (is (= (aot/compile-element '[:> x {:x 1 :ref 2} 1 2] nil)
-         '(uix.compiler.aot/>el x (cljs.core/array (js* "{'x':~{},'ref':~{}}" 1 2)) (cljs.core/array 1 2)))))
+  (is (= (aot/compile-element '[x {} 1 2] nil)
+         '(uix.compiler.alpha/component-element x (cljs.core/array {}) (cljs.core/array 1 2))))
+  (is (= (aot/compile-element '[x {:x 1 :ref 2} 1 2] nil)
+         '(uix.compiler.alpha/component-element x (cljs.core/array {:x 1 :ref 2}) (cljs.core/array 1 2)))))

--- a/core/test/uix/compiler_test.cljs
+++ b/core/test/uix/compiler_test.cljs
@@ -154,11 +154,12 @@
            (as-string ($ comp3))))))
 
 (deftest test-interop
+  (defn testc-interop [])
   (testing "Interop element type"
-    (is (.-type ($ :> inc))
-        inc))
+    (is (.-type ($ testc-interop))
+        testc-interop))
   (testing "Shallowly converted props"
-    (let [el ($ :> inc {:a 1 :b {:c 2}} :child)
+    (let [el ($ testc-interop {:a 1 :b {:c 2}} :child)
           props (.-props el)]
       (is (.-a props) 1)
       (is (.-b props) {:c 2})
@@ -182,17 +183,17 @@
     (is (= (.-children props) "TEXT"))))
 
 (deftest test-validate-component
-  (is (thrown-with-msg? js/Error #"Invalid use of a non-UIx component test in `\$` form\..*"
-                        (uixc/validate-component #js {:name "test"})))
-  (when ^boolean goog.DEBUG
-    (is (thrown-with-msg? js/Error #"Invalid use of a non-UIx component cljs\$core\$inc in `\$` form\..*"
-                          ($ inc))))
-  (let [target #js {:name "test"}]
-    (set! (.-uix-component? target) true)
-    (is (true? (uixc/validate-component target))))
-  (when ^boolean goog.DEBUG
-    (uix.core/defui test-comp [] "x")
-    (is (= test-comp (.-type ($ test-comp))))))
+  (defn testc-validate-component-1 [])
+  (defn testc-validate-component-2 [])
+  (defn testc-validate-component-3 [])
+  (aset testc-validate-component-1 "G_1" testc-validate-component-1)
+  (is (thrown-with-msg? js/Error #"Invalid use of Reagent component uix\$compiler_test\$testc_validate_component_1 in.*"
+                        (uixc/validate-component testc-validate-component-1)))
+  (is (thrown-with-msg? js/Error #"Invalid use of Reagent component uix\$compiler_test\$testc_validate_component_1 in.*"
+                        ($ testc-validate-component-1)))
+  (set! (.-uix-component? ^clj testc-validate-component-2) true)
+  (is (true? (uixc/validate-component testc-validate-component-2)))
+  (is (true? (uixc/validate-component testc-validate-component-3))))
 
 (deftest test-nil-attrs
   (defui test-nil-attrs-component [])

--- a/core/test/uix/core_test.clj
+++ b/core/test/uix/core_test.clj
@@ -19,10 +19,10 @@
 (deftest test-$
   (is (= (macroexpand-1 '(uix.core/$ :h1))
          '(uix.compiler.aot/>el "h1" (cljs.core/array nil) (cljs.core/array))))
-  (is (= (macroexpand-1 '(uix.core/$ :> identity {} 1 2))
-         '(uix.compiler.aot/>el identity (cljs.core/array (cljs.core/js-obj)) (cljs.core/array 1 2))))
-  (is (= (macroexpand-1 '(uix.core/$ :> identity {:x 1 :ref 2} 1 2))
-         '(uix.compiler.aot/>el identity (cljs.core/array (js* "{'x':~{},'ref':~{}}" 1 2)) (cljs.core/array 1 2)))))
+  (is (= (macroexpand-1 '(uix.core/$ identity {} 1 2))
+         '(uix.compiler.alpha/component-element identity (cljs.core/array {}) (cljs.core/array 1 2))))
+  (is (= (macroexpand-1 '(uix.core/$ identity {:x 1 :ref 2} 1 2))
+         '(uix.compiler.alpha/component-element identity (cljs.core/array {:x 1 :ref 2}) (cljs.core/array 1 2)))))
 
 (defn test-linter [form expected-messages]
   (let [errors (atom [])

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -5,7 +5,7 @@
             [react :as r]
             [react-dom]
             [uix.test-utils :as t]
-            [cljs-bean.core :as bean]))
+            [uix.compiler.attributes :as attrs]))
 
 (deftest test-lib
   (is (= (seq (uix.lib/re-seq* (re-pattern "foo") "foo bar foo baz foo zot"))
@@ -103,6 +103,32 @@
     (is (= "Hello!" (.-textContent root)))
     (react-dom/unmountComponentAtNode root)
     (is (:componentWillUnmount @actual))))
+
+(deftest test-convert-props
+  (testing "shallow conversion"
+    (let [obj (attrs/convert-props
+               {:x 1
+                :y :keyword
+                :f identity
+                :style {:border :red}
+                :class :class
+                :for :for
+                :charset :charset
+                :hello-world "yo"
+                "yo-yo" "string"
+                :plugins [1 2 3]}
+               #js []
+               true)]
+      (is (= 1 (.-x obj)))
+      (is (= :keyword (.-y obj)))
+      (is (= identity (.-f obj)))
+      (is (= {:border :red} (.-style obj)))
+      (is (= :class (.-class obj)))
+      (is (= :for (.-for obj)))
+      (is (= :charset (.-charset obj)))
+      (is (= "yo" (.-helloWorld obj)))
+      (is (= [1 2 3] (.-plugins obj)))
+      (is (= "string" (aget obj "yo-yo"))))))
 
 (defn -main []
   (run-tests))

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -110,7 +110,8 @@
                {:x 1
                 :y :keyword
                 :f identity
-                :style {:border :red}
+                :style {:border :red
+                        :margin-top "12px"}
                 :class :class
                 :for :for
                 :charset :charset
@@ -123,6 +124,7 @@
       (is (= "keyword" (.-y obj)))
       (is (= identity (.-f obj)))
       (is (= "red" (.. obj -style -border)))
+      (is (= "12px" (.. obj -style -marginTop)))
       (is (= "class" (.-className obj)))
       (is (= "for" (.-htmlFor obj)))
       (is (= "charset" (.-charSet obj)))

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -117,7 +117,9 @@
                 :charset :charset
                 :hello-world "yo"
                 "yo-yo" "string"
-                :plugins [1 2 3]}
+                :plugins [1 2 3]
+                :data-test-id "hello"
+                :aria-role "button"}
                #js []
                true)]
       (is (= 1 (.-x obj)))
@@ -130,7 +132,10 @@
       (is (= "charset" (.-charSet obj)))
       (is (= "yo" (.-helloWorld obj)))
       (is (= [1 2 3] (.-plugins obj)))
-      (is (= "string" (aget obj "yo-yo"))))))
+      (is (= "string" (aget obj "yo-yo")))
+      (is (= "hello" (aget obj "data-test-id")))
+      (is (= "button" (aget obj "aria-role")))
+      (is (= "a b c" (.-className (attrs/convert-props {:class [:a :b "c"]} #js [] true)))))))
 
 (defn -main []
   (run-tests))

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -120,12 +120,12 @@
                #js []
                true)]
       (is (= 1 (.-x obj)))
-      (is (= :keyword (.-y obj)))
+      (is (= "keyword" (.-y obj)))
       (is (= identity (.-f obj)))
-      (is (= {:border :red} (.-style obj)))
-      (is (= :class (.-class obj)))
-      (is (= :for (.-for obj)))
-      (is (= :charset (.-charset obj)))
+      (is (= "red" (.. obj -style -border)))
+      (is (= "class" (.-className obj)))
+      (is (= "for" (.-htmlFor obj)))
+      (is (= "charset" (.-charSet obj)))
       (is (= "yo" (.-helloWorld obj)))
       (is (= [1 2 3] (.-plugins obj)))
       (is (= "string" (aget obj "yo-yo"))))))

--- a/docs/code-splitting.md
+++ b/docs/code-splitting.md
@@ -28,7 +28,7 @@ Similarly to React, with UIx you can use `uix.core/lazy` that will take care of 
     ($ :div
       ($ :button {:on-click #(set-show-modal! true)})
       ;; wrap the "lazy" `modal` with React's `Suspense` component and provide a fallback UI
-      ($ :> react/Suspense {:fallback ($ :div "Loading...")}
+      ($ react/Suspense {:fallback ($ :div "Loading...")}
         (when show-modal?
           ;; when rendered, React will load the module while displaying the fallback
           ;; and then render the component referenced from the module

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -33,7 +33,7 @@ Component instance is also created via `$` macro call, where the first argument 
 
 ## React component instances
 
-React components wriiten in JavaScript can be used directly in UIx with a minor difference in how props are passed into a component, more on that in [“Interop with React”](/docs/interop-with-react.md) page.
+React components written in JavaScript can be used directly in UIx with a minor difference in how props are passed into a component, more on that in [“Interop with React”](/docs/interop-with-react.md) page.
 
 ```clojure
 ($ Button {:on-click #(js/console.log :click)}

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -31,11 +31,11 @@ Component instance is also created via `$` macro call, where the first argument 
   "press me")
 ```
 
-## Interop elements
+## React component instances
 
-Interop syntax exists to allow using React components written in JavaScript as UIx components. More on that in [“Interop with React”](/docs/interop-with-react.md) page.
+React components wriiten in JavaScript can be used directly in UIx with a minor difference in how props are passed into a component, more on that in [“Interop with React”](/docs/interop-with-react.md) page.
 
 ```clojure
-($ :> Button {:on-click #(js/console.log :click)}
-    "press me")
+($ Button {:on-click #(js/console.log :click)}
+  "press me")
 ```

--- a/docs/interop-with-react.md
+++ b/docs/interop-with-react.md
@@ -34,7 +34,7 @@ When a non-UIx component is passed into `$`, props map is converted into JS obje
      - `:for` -> `"htmlFor"`
      - `:charset` -> `"charSet"`
 1. When a component expects a kebab-cased key, it can be passed as a string to avoid conversion.
-1. props map is converted _shallowly_ into JavaScript object, meaning that nested collections and maps are not converted. If a JS component expects a prop to hold an array or object, you have to pass it explicitly. There are two exceptions though:
+1. props map is converted _shallowly_ into a JavaScript object, meaning that nested collections and maps are not converted. If a JS component expects a prop to hold an array or an object, you have to pass it explicitly. There are two exceptions though:
 
    - `:style` map is an exceptions, it is always converted into JS object because it's a common prop when passing styles into a third-party component.
    - Keyword values are converted into string.

--- a/docs/interop-with-react.md
+++ b/docs/interop-with-react.md
@@ -2,40 +2,40 @@
 
 ## Using React components in UIx
 
-In [“Elements”](/docs/elements.md) section we've learned about special interop syntax for consuming React components written in JavaScript.
+In [“Elements”](/docs/elements.md) section it was briefly mentioned that React components written in JavaScript can be used in `$` macro, but with a difference in how props are passed into such a component.
 
 As an example lets say we have `Button` component that we want to use in UIx component.
 
 ```js
-function Button({ onClick, children }) {
-  return <button onClick={onClick}>{children}</button>;
+function Button({ onClick, title, style, className, children }) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      style={style}
+      className={className.join(" ")}
+    >
+      {children}
+    </button>
+  );
 }
 ```
 
 Here’s how to use it in UIx:
 
 ```clojure
-($ :> Button {:on-click #(js/console.log :click)}
-    "press me")
+($ Button {:on-click #(js/console.log :click)
+           :title "this is a button"
+           :style #js {:border "1px solid red"}
+           :class-name #js ["hello" "world"]}
+  "press me")
 ```
 
-Interop element starts with a special marker `:>`, followed by JS component, that instructs UIx to handle provided component in a special way:
+When a non-UIx component is passed into `$`, props map is converted into JS object using the following set of rules:
 
-1. The first argument to JS component is optional map of attributes
-   - Map of attributes is _shallowly_ transformed into JavaScript object, meaning that it is your responsibility to pass nested objects as proper JS objects or arrays
-   - `:style` attribute is the only exception, the value can be Clojure’s hash map which will be turned into JS object
-   - Keys in kebab case are transformed into camel case
-2. The rest are child components
-
-> UIx components wrapped with React.lazy or React.memo can be created as usual UIx components, there's no need for :> syntax, this will not actually work.
-
-```clojure
-(defui button [props] ...)
-
-(def memoized-button (react/memo button))
-
-($ memoized-button {:on-click handle-click})
-```
+1. kebab-cased keys are automatically converted into camel-cased keys.
+1. When a component expects a kebab-cased key, it can be passed as a string to avoid conversion.
+1. props map is converted _shallowly_ into JavaScript object, meaning that nested collections and maps are not converted. If a JS component expects a prop to hold an array or object, you have to pass it explicitly. This is illustrated in the example above where `Button` expects `className` props to be JS array and `style` to be an object.
 
 ## Using UIx components in React
 

--- a/docs/interop-with-react.md
+++ b/docs/interop-with-react.md
@@ -37,7 +37,7 @@ When a non-UIx component is passed into `$`, props map is converted into JS obje
 1. props map is converted _shallowly_ into a JavaScript object, meaning that nested collections and maps are not converted. If a JS component expects a prop to hold an array or an object, you have to pass it explicitly. There are two exceptions though:
 
    - `:style` map is an exceptions, it is always converted into JS object because it's a common prop when passing styles into a third-party component.
-   - Keyword values are converted into string.
+   - Keyword values are converted into strings.
 
 ## Using UIx components in React
 

--- a/docs/interop-with-react.md
+++ b/docs/interop-with-react.md
@@ -9,12 +9,7 @@ As an example lets say we have `Button` component that we want to use in UIx com
 ```js
 function Button({ onClick, title, style, className, children }) {
   return (
-    <button
-      onClick={onClick}
-      title={title}
-      style={style}
-      className={className.join(" ")}
-    >
+    <button onClick={onClick} title={title} style={style} className={className}>
       {children}
     </button>
   );
@@ -26,16 +21,23 @@ Here’s how to use it in UIx:
 ```clojure
 ($ Button {:on-click #(js/console.log :click)
            :title "this is a button"
-           :style #js {:border "1px solid red"}
-           :class-name #js ["hello" "world"]}
+           :style {:border "1px solid red"}
+           :class :button}
   "press me")
 ```
 
 When a non-UIx component is passed into `$`, props map is converted into JS object using the following set of rules:
 
 1. kebab-cased keys are automatically converted into camel-cased keys.
+   - Similarly to DOM elements props, the following keys are renamed into their React counterparts:
+     - `:class` -> `"className"`
+     - `:for` -> `"htmlFor"`
+     - `:charset` -> `"charSet"`
 1. When a component expects a kebab-cased key, it can be passed as a string to avoid conversion.
-1. props map is converted _shallowly_ into JavaScript object, meaning that nested collections and maps are not converted. If a JS component expects a prop to hold an array or object, you have to pass it explicitly. This is illustrated in the example above where `Button` expects `className` props to be JS array and `style` to be an object.
+1. props map is converted _shallowly_ into JavaScript object, meaning that nested collections and maps are not converted. If a JS component expects a prop to hold an array or object, you have to pass it explicitly. There are two exceptions though:
+
+   - `:style` map is an exceptions, it is always converted into JS object because it's a common prop when passing styles into a third-party component.
+   - Keyword values are converted into string.
 
 ## Using UIx components in React
 

--- a/docs/interop-with-react.md
+++ b/docs/interop-with-react.md
@@ -36,7 +36,7 @@ When a non-UIx component is passed into `$`, props map is converted into JS obje
 1. When a component expects a kebab-cased key, it can be passed as a string to avoid conversion.
 1. props map is converted _shallowly_ into a JavaScript object, meaning that nested collections and maps are not converted. If a JS component expects a prop to hold an array or an object, you have to pass it explicitly. There are two exceptions though:
 
-   - `:style` map is an exceptions, it is always converted into JS object because it's a common prop when passing styles into a third-party component.
+   - `:style` map is always converted into a JS object because it's a common prop, when passing styles into a third-party component.
    - Keyword values are converted into strings.
 
 ## Using UIx components in React

--- a/docs/migrating-from-reagent.md
+++ b/docs/migrating-from-reagent.md
@@ -153,6 +153,6 @@ In Reagent it's common to have shared state in a form of a global var that holds
   ;; declare local state to be shared in UI subtree
   (let [[n set-n!] (uix/use-state 0)]
     ;; share the state with the subtree via context
-    ($ :> (.-Provider state-context) {:value [n set-n!]}
+    ($ (.-Provider state-context) {:value [n set-n!]}
       ($ child-component))))
 ```


### PR DESCRIPTION
before
```clojure
($ :> some-lib/Component {...} ...)
```

now
```clojure
($ some-lib/Component {...} ...)
```

Props conversion is strictly shallow (a map is turned into JS object only at top level, values are left as is)
1. kebab-cased keys are automatically converted into camel-cased keys.
1. When a component expects a kebab-cased key, it can be passed as a string to avoid conversion.
1. props map is converted _shallowly_ into JavaScript object, meaning that nested collections, maps and keywords are not converted. This is useful because sometimes a component just passes through a value, Context Provider is one of such components `($ (.-Provider state-context) {:value [n set-n!]})`.