### PR TITLE
enrich elements with debug source info in dev

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -19,28 +19,36 @@
                              "Reagent element should be Hiccup wrapped with r/as-element, i.e. (r/as-element [" name-str "])")))))
   true)
 
-(defn- uix-component-element [component-type ^js props-children children]
+(defn- with-debug-source [js-props debug-source]
+  (when ^boolean goog.DEBUG
+    (when debug-source
+      (set! (.-__source js-props) debug-source)))
+  js-props)
+
+(defn- uix-component-element [component-type ^js props-children children debug-source]
   (let [props (aget props-children 0)
         js-props (if-some [key (:key props)]
                    #js {:key key :argv (dissoc props :key)}
                    #js {:argv props})
+        js-props (with-debug-source js-props debug-source)
         args (if (= 2 (.-length props-children))
                #js [component-type js-props (aget props-children 1)]
                #js [component-type js-props])]
     (.apply react/createElement nil (.concat args children))))
 
-(defn- react-component-element [component-type ^js props-children children]
+(defn- react-component-element [component-type ^js props-children children debug-source]
   (let [js-props (-> (aget props-children 0)
                      (attrs/interpret-attrs #js [] true)
                      (aget 0))
+        js-props (with-debug-source js-props debug-source)
         args (if (= 2 (.-length props-children))
                #js [component-type js-props (aget props-children 1)]
                #js [component-type js-props])]
     (.apply react/createElement nil (.concat args children))))
 
-(defn component-element [^clj component-type props-children children]
+(defn component-element [^clj component-type props-children children debug-source]
   (when ^boolean goog.DEBUG
     (validate-component component-type))
   (if (.-uix-component? component-type)
-    (uix-component-element component-type props-children children)
-    (react-component-element component-type props-children children)))
+    (uix-component-element component-type props-children children debug-source)
+    (react-component-element component-type props-children children debug-source)))

--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -26,12 +26,17 @@
       (validate-children child)))
   true)
 
+(defn- with-debug-source [args debug-source]
+  (when debug-source
+    (let [props (or (aget args 1) #js {})]
+      (set! (.-__source props) debug-source)
+      (aset args 1 props))))
+
 (defn >el [tag attrs-children children debug-source]
   (let [args (-> #js [tag] (.concat attrs-children) (.concat children))]
     (when ^boolean goog.DEBUG
       (validate-children (.slice args 2))
-      (when debug-source
-        (set! (.-__source (aget args 1)) debug-source)))
+      (with-debug-source args debug-source))
     (.apply react/createElement nil args)))
 
 (defn create-uix-input [tag attrs-children children debug-source]

--- a/core/src/uix/compiler/aot.cljs
+++ b/core/src/uix/compiler/aot.cljs
@@ -26,17 +26,19 @@
       (validate-children child)))
   true)
 
-(defn >el [tag attrs-children children]
+(defn >el [tag attrs-children children debug-source]
   (let [args (-> #js [tag] (.concat attrs-children) (.concat children))]
     (when ^boolean goog.DEBUG
-      (validate-children (.slice args 2)))
+      (validate-children (.slice args 2))
+      (when debug-source
+        (set! (.-__source (aget args 1)) debug-source)))
     (.apply react/createElement nil args)))
 
-(defn create-uix-input [tag attrs-children children]
+(defn create-uix-input [tag attrs-children children debug-source]
   (if (uix.compiler.input/should-use-reagent-input?)
     (let [props (aget attrs-children 0)
           children (.concat #js [(aget attrs-children 1)] children)]
       (react/createElement uix.compiler.input/reagent-input #js {:props props :tag tag :children children}))
-    (>el tag attrs-children children)))
+    (>el tag attrs-children children debug-source)))
 
 (def fragment react/Fragment)

--- a/core/test/uix/aot_test.clj
+++ b/core/test/uix/aot_test.clj
@@ -36,8 +36,11 @@
 
 (deftest test-compile-html
   (is (= (aot/compile-element [:h1] nil)
-         '(uix.compiler.aot/>el "h1" (cljs.core/array nil) (cljs.core/array))))
+         '(uix.compiler.aot/>el "h1" (cljs.core/array nil) (cljs.core/array)
+                                (clojure.core/when goog.DEBUG (js* "{'fileName':~{},'lineNumber':~{},'columnNumber':~{}}" nil nil nil)))))
   (is (= (aot/compile-element '[x {} 1 2] nil)
-         '(uix.compiler.alpha/component-element x (cljs.core/array {}) (cljs.core/array 1 2))))
+         '(uix.compiler.alpha/component-element x (cljs.core/array {}) (cljs.core/array 1 2)
+                                                (clojure.core/when goog.DEBUG (js* "{'fileName':~{},'lineNumber':~{},'columnNumber':~{}}" nil nil nil)))))
   (is (= (aot/compile-element '[x {:x 1 :ref 2} 1 2] nil)
-         '(uix.compiler.alpha/component-element x (cljs.core/array {:x 1 :ref 2}) (cljs.core/array 1 2)))))
+         '(uix.compiler.alpha/component-element x (cljs.core/array {:x 1 :ref 2}) (cljs.core/array 1 2)
+                                                (clojure.core/when goog.DEBUG (js* "{'fileName':~{},'lineNumber':~{},'columnNumber':~{}}" nil nil nil))))))

--- a/core/test/uix/core_test.clj
+++ b/core/test/uix/core_test.clj
@@ -18,11 +18,14 @@
 
 (deftest test-$
   (is (= (macroexpand-1 '(uix.core/$ :h1))
-         '(uix.compiler.aot/>el "h1" (cljs.core/array nil) (cljs.core/array))))
+         '(uix.compiler.aot/>el "h1" (cljs.core/array nil) (cljs.core/array)
+                                (clojure.core/when goog.DEBUG (js* "{'fileName':~{},'lineNumber':~{},'columnNumber':~{}}" nil nil nil)))))
   (is (= (macroexpand-1 '(uix.core/$ identity {} 1 2))
-         '(uix.compiler.alpha/component-element identity (cljs.core/array {}) (cljs.core/array 1 2))))
+         '(uix.compiler.alpha/component-element identity (cljs.core/array {}) (cljs.core/array 1 2)
+                                                (clojure.core/when goog.DEBUG (js* "{'fileName':~{},'lineNumber':~{},'columnNumber':~{}}" nil nil nil)))))
   (is (= (macroexpand-1 '(uix.core/$ identity {:x 1 :ref 2} 1 2))
-         '(uix.compiler.alpha/component-element identity (cljs.core/array {:x 1 :ref 2}) (cljs.core/array 1 2)))))
+         '(uix.compiler.alpha/component-element identity (cljs.core/array {:x 1 :ref 2}) (cljs.core/array 1 2)
+                                                (clojure.core/when goog.DEBUG (js* "{'fileName':~{},'lineNumber':~{},'columnNumber':~{}}" nil nil nil))))))
 
 (defn test-linter [form expected-messages]
   (let [errors (atom [])

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -151,5 +151,15 @@
   (is (= (uix.core/source row-compiled)
          "(defui row-compiled [{:keys [children]}]\n  ($ :div.row children))")))
 
+(deftest test-debug-source
+  (let [dom-el ($ :h1)
+        comp-el ($ :h1)]
+    (is (= 155 (.. dom-el  -_source -lineNumber)))
+    (is (= 16 (.. dom-el  -_source -columnNumber)))
+    (is (= "uix/core_test.cljs" (.. dom-el  -_source -fileName)))
+    (is (= 156 (.. comp-el  -_source -lineNumber)))
+    (is (= 17 (.. comp-el  -_source -columnNumber)))
+    (is (= "uix/core_test.cljs" (.. comp-el  -_source -fileName)))))
+
 (defn -main []
   (run-tests))


### PR DESCRIPTION
UIx elements are enriched with source information (similar to https://babeljs.io/docs/en/babel-plugin-transform-react-jsx-source) to allow filtering components by name in React DevTools