### PR TITLE
swap-like state updater fn

### DIFF
--- a/core/src/uix/hooks/alpha.cljs
+++ b/core/src/uix/hooks/alpha.cljs
@@ -5,7 +5,13 @@
 ;; == State hook ==
 
 (defn use-state [value]
-  (r/useState value))
+  (let [[v set-v] (r/useState value)
+        enhanced-set-v (react/useCallback (fn [f & args]
+                                            (if (fn? f)
+                                              (set-v #(apply f % args))
+                                              (set-v f)))
+                                          #js [set-v])]
+    #js [v enhanced-set-v]))
 
 (defn use-reducer
   ([f value]

--- a/core/test/uix/hooks_test.cljs
+++ b/core/test/uix/hooks_test.cljs
@@ -1,6 +1,49 @@
 (ns uix.hooks-test
   (:require [clojure.test :refer [deftest is testing run-tests async]]
-            [uix.core :as core]))
+            [uix.core :refer [defui $]]
+            [uix.dom]
+            ["react-dom/test-utils" :as rdom.test]))
+
+(defn simulate [event node]
+  (let [f (aget rdom.test/Simulate (name event))]
+    (f node)))
+
+(defn act [f]
+  (rdom.test/act #(let [ret (f)]
+                    (if (instance? js/Promise ret) ret js/undefined))))
+
+(defn with-dom-node [f]
+  (let [node (.createElement js/document "div")]
+    (js/document.body.appendChild node)
+    (f node)
+    (uix.dom/unmount-at-node node)
+    (.remove node)))
+
+(defui test-use-state-comp []
+  (let [[v set-v] (uix.core/use-state 0)]
+    ($ :button {:on-click #(set-v inc)}
+       v)))
+
+(defui test-use-state-updater-comp []
+  (let [[v set-v] (uix.core/use-state {:n 0})]
+    ($ :button {:on-click #(set-v update :n inc)}
+       (:n v))))
+
+(deftest test-use-state
+  (testing "simple set-state"
+    (with-dom-node
+      (fn [^js node]
+        (act #(uix.dom/render ($ test-use-state-comp) node))
+        (is (= "0" (.-textContent node)))
+        (simulate :click (first (.-children node)))
+        (is (= "1" (.-textContent node))))))
+  (testing "simple swap-like set-state"
+    (with-dom-node
+      (fn [^js node]
+        (act #(uix.dom/render ($ test-use-state-updater-comp) node))
+        (is (= "0" (.-textContent node)))
+        (simulate :click (first (.-children node)))
+        (is (= "1" (.-textContent node)))))))
 
 (defn -main []
   (run-tests))


### PR DESCRIPTION
Upgrades `use-state`'s updater fn to be more like `swap!`, where it takes updater function and additional arguments that will be passed after current state value.

before
```clojure
(defui component []
  (let [[user set-user] (uix.core/use-state {:name "" :age 35})]
    ($ :input {:type :number
               :value (:age user)
               :on-change #(set-user (assoc user :age %))})))
```

after
```clojure
(defui component []
  (let [[user update-user] (uix.core/use-state {:name "" :age 35})]
    ($ :input {:type :number
               :value (:age user)
               :on-change #(update-user assoc :age %)})))
```