### PR TITLE
expose component linting api

### DIFF
--- a/core/deps.edn
+++ b/core/deps.edn
@@ -7,7 +7,7 @@
                                     enlive/enlive {:mvn/version "1.1.6"}
                                     hiccup/hiccup {:mvn/version "1.0.5"}
                                     rum/rum {:mvn/version "0.11.2"}}}
-           :test {:extra-paths ["test"]
+           :test {:extra-paths ["test" "dev"]
                   :extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}
                                org.clojure/clojurescript {:mvn/version "1.10.879"}
                                thheller/shadow-cljs {:mvn/version "2.15.5"}

--- a/core/dev/uix/examples.cljs
+++ b/core/dev/uix/examples.cljs
@@ -1,0 +1,1 @@
+(ns uix.examples)

--- a/core/dev/uix/linters.clj
+++ b/core/dev/uix/linters.clj
@@ -1,0 +1,35 @@
+(ns uix.linters
+  (:require
+    [cljs.analyzer :as ana]
+    [clojure.pprint :as pprint]
+    [uix.linter :as linter]))
+
+;; per element linting
+(defmethod linter/lint-element :element/no-inline-styles [_ form env]
+  (let [[_ tag props & children] form]
+    (when (and (keyword? tag)
+               (map? props)
+               (contains? props :style))
+      (linter/add-error! form :element/no-inline-styles (linter/form->loc (:style props))))))
+
+(defmethod ana/error-message :element/no-inline-styles [_ _]
+  "Inline styles are not allowed, put them into a CSS file instead")
+
+;; Hooks linting
+(defmethod linter/lint-hook-with-deps :hooks/too-many-lines [_ form env]
+  (when (> (count (str form)) 180)
+    (linter/add-error! form :hooks/too-many-lines (linter/form->loc form))))
+
+(defmethod ana/error-message :hooks/too-many-lines [_ {:keys [source]}]
+  (str "React hook is too large to be declared directly in component's body, consider extracting it into a custom hook:\n\n"
+       (with-out-str (pprint/pprint `(~'defn ~'use-my-hook []
+                                       ~source)))))
+
+;; Components linting
+(defmethod linter/lint-component :component/kebab-case-name [_ form env]
+  (let [[_ sym] form]
+    (when-not (re-matches #"[a-z-]+" (str sym))
+      (linter/add-error! form :component/kebab-case-name (linter/form->loc sym)))))
+
+(defmethod ana/error-message :component/kebab-case-name [_ _]
+  "Component name should be in kebab case")

--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -86,7 +86,7 @@
   A component should have a single argument of props."
   [sym & fdecl]
   (let [[fname args fdecl] (parse-sig `defui sym fdecl)]
-    (uix.linter/lint! sym fdecl &env)
+    (uix.linter/lint! sym fdecl &form &env)
     (if (uix.lib/cljs-env? &env)
       (let [var-sym (-> (str (-> &env :ns :name) "/" sym) symbol (with-meta {:tag 'js}))
             body (uix.dev/with-fast-refresh var-sym fdecl)]
@@ -108,7 +108,7 @@
                       [(first fdecl) (rest fdecl)]
                       [(gensym "uix-fn") fdecl])
         [fname args body] (parse-sig `fn sym fdecl)]
-    (uix.linter/lint! sym body &env)
+    (uix.linter/lint! sym body &form &env)
     (if (uix.lib/cljs-env? &env)
       (let [var-sym (with-meta sym {:tag 'js})]
         `(let [~var-sym ~(if (empty? args)
@@ -131,8 +131,10 @@
   DOM element: ($ :button#id.class {:on-click handle-click} \"click me\")
   React component: ($ title-bar {:title \"Title\"})"
   ([tag]
+   (uix.linter/lint-element* &form &env)
    (uix.compiler.aot/compile-element [tag] {:env &env}))
   ([tag props & children]
+   (uix.linter/lint-element* &form &env)
    (uix.compiler.aot/compile-element (into [tag props] children) {:env &env})))
 
 ;; === Hooks ===

--- a/core/test/uix/linter_test.clj
+++ b/core/test/uix/linter_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [shadow.cljs.devtools.cli]
             [uix.linter]
+            [uix.linters]
             [clojure.string :as str]))
 
 ;; === Rules of Hooks ===
@@ -265,4 +266,12 @@
       (is (str/includes? out-str "UIx element is missing :key attribute, which is required"))
       (is (str/includes? out-str "($ :div.test-missing-key {} x)"))
       (is (str/includes? out-str "($ :div.test-missing-key ($ x))"))
-      (is (str/includes? out-str "($ :div.test-missing-key-nested ($ x))")))))
+      (is (str/includes? out-str "($ :div.test-missing-key-nested ($ x))")))
+
+    (testing "plugin linters should work"
+      (is (str/includes? out-str (str :component/kebab-case-name)))
+      (is (str/includes? out-str (str :hooks/too-many-lines)))
+      (is (str/includes? out-str (str :element/no-inline-styles)))
+      (is (str/includes? out-str "Component name should be in kebab case"))
+      (is (str/includes? out-str "React hook is too large to be declared directly in component's body"))
+      (is (str/includes? out-str "Inline styles are not allowed, put them into a CSS file instead")))))

--- a/core/test/uix/linter_test.cljs
+++ b/core/test/uix/linter_test.cljs
@@ -65,3 +65,14 @@
       (do
         ($ :div.test-missing-key ($ x))
         ($ :div.test-missing-key-nested ($ x))))))
+
+(defui Button [{:keys [on-click children]}]
+  (uix.core/use-effect
+   (fn []
+     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+   [])
+  ($ :button {:on-click on-click
+              :style {:color "red"}}
+     children))


### PR DESCRIPTION
Exposes UIx component linter

Usage
```clojure
(ns app.code
  ;; have to require .clj ns with a linter so that it gets registered
  (:require-macros [app.my-linter]))
```

```clojure
;; app/my-linter.clj
(ns app.my-linter
  (:require
    [cljs.analyzer :as ana]
    [uix.linter]))

(defn lint-a11y-button [[_ el attrs & children :as form]]
  (cond
    ;; no attrs
    (not (map? attrs))
    ;; points to an element since there's no attrs map
    (uix.linter/add-error! form :a11y/aria-label (uix.linter/form->loc form))

    ;; no :aria-label in attrs
    (nil? (:aria-label attrs))
    ;; points to attrs map
    (uix.linter/add-error! form :a11y/aria-label (uix.linter/form->loc attrs))))

(defn lint-element [form]
  (let [[_ el attrs & children] form]
    (case el
      :button (lint-a11y-button form) ;; lints a `button` element
      nil)))

(defn lint-aria [expr]
  ;; walks component's body
  (clojure.walk/prewalk
    (fn [form]
      (when (uix.linter/uix-element? form)
        (lint-element form)) ;; lints `($ ...)` element
      form)
    expr))

;; register your linter
(defmethod uix.linter/lint-component :a11y/element [_ sym body env]
  ;; `body` is a seq of top level expressions in a `defui` component
  (run! lint-aria body))

;; register error printers
(defmethod ana/error-message :a11y/aria-label [_ {:keys [source] :as v}]
  (let [[_ el] source]
    (str "The " el " is missing aria-label attribute")))
```

An example of the error message
<img width="494" alt="Screenshot 2023-01-27 at 3 25 37 PM" src="https://user-images.githubusercontent.com/1355501/215100071-b45de517-04ff-4277-8ffc-1ace4e0b3d09.png">
