### PR TITLE
Update the SSR example

### DIFF
--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -63,12 +63,9 @@ For that it's recommended to put shared code in `.cljc` namespaces and use [read
   (:require [uix.core :refer [$]]
             [uix.dom :as dom.client]
             [app.ui :as ui]))
-
-(defonce root
-  (dom.client/create-root (js/document.getElementById "root")))
-
+            
 ;; Hydrates server generated HTML into dynamic React UI
-(dom.client/hydrate-root root ($ ui/title-bar))
+(dom.client/hydrate-root (js/document.getElementById "root") ($ ui/title-bar))
 ```
 
 ## Hooks


### PR DESCRIPTION
The example provided didn't work, as you need a DOM element for hydrate root, instead of a React root 🙂 

https://beta.reactjs.org/reference/react-dom/client/createRoot#caveats