### PR TITLE
Add exportable Kondo config

### DIFF
--- a/core/deps.edn
+++ b/core/deps.edn
@@ -1,5 +1,5 @@
 {:deps {cljs-bean/cljs-bean {:mvn/version "1.8.0"}}
- :paths ["src"]
+ :paths ["src" "resources"]
  :aliases {:dev {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}}
            :benchmark {:extra-paths ["benchmark"]
                        :extra-deps {reagent/reagent {:mvn/version "1.1.0"}

--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
@@ -1,3 +1,4 @@
 {:lint-as {uix.core/fn    clojure.core/fn
-           uix.core/defui clojure.core/defn}}
-
+           uix.core/defui clojure.core/defn
+           uix.core/$     hooks.uix/$}
+ :linters {:uix.core/$-arg-validation {:level :warning}}}

--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
@@ -1,0 +1,3 @@
+{:lint-as {uix.core/fn    clojure.core/fn
+           uix.core/defui clojure.core/defn}}
+

--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
@@ -1,0 +1,10 @@
+(ns hooks.uix
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn $ [{:keys [node]}]
+  (let [[sym _args] (rest (api/sexpr node))]
+    (when-not (or (symbol? sym)
+                  (keyword? sym))
+      (api/reg-finding! (-> (meta node)
+                            (merge {:message "First arg to $ must be a symbol or keyword"
+                                    :type    :uix.core/$-arg-validation}))))))

--- a/docs/code-linting.md
+++ b/docs/code-linting.md
@@ -204,10 +204,18 @@ It is possible to add re-frame specific rules to the linter config file (located
   ;; re-frame.core/subscribe is checked by default
 ```
 
-## Custom linters
+# Custom linters
 UIx exposes a public API to register custom linters, so that you can have your own linting rules specific to your project. There are three types of linters in UIx:
 - Component linters `uix.linter/lint-component` — those execute on entire `defui` form
 - Element linters `uix.linter/lint-element` — execute per `$` form
 - Hook linters `uix.linter/lint-hook-with-deps` — execute for every Hook form that takes deps (`use-effect`, `use-callback`, etc.)
 
 See [core/dev/uix/linters.clj](/core/dev/uix/linters.clj) for a set of complete examples.
+
+# clj-kondo
+
+UIx has importable configuration for clj-kondo. You can important the configuration with:
+```bash
+clj-kondo --lint "$(clojure -Spath)" --copy-configs --skip-lint
+```
+There is only one custom hook, which validates the arguments passed to `uix.core/$`. 


### PR DESCRIPTION
This adds a Kondo config file that can be [imported](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#importing) to fix Kondo warnings on `uix.core/defui` and `uix.core/fn`.

I haven't written custom hooks for these (yet), because both `fn` and `defui` are nearly identical to their Clojure core counterparts 🙂 