### PR TITLE
Add error boundary support, based on UIx v1 implementation

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -137,6 +137,25 @@
    (uix.linter/lint-element* &form &env)
    (uix.compiler.aot/compile-element (into [tag props] children) {:env &env})))
 
+;; === Error boundary ===
+
+(defn create-error-boundary
+  "Creates React's error boundary component
+
+  display-name       — the name of the component to be displayed in stack trace
+  derive-error-state — maps error object to component's state that is used in render-fn
+  did-catch          — 2 arg function for side-effects, logging etc.
+  receives the exception and additional component info as args
+  render-fn          — takes state value returned from derive-error-state and a vector
+  of arguments passed into error boundary"
+  [{:keys [display-name derive-error-state did-catch]
+    :or   {display-name (str (gensym "uix.error-boundary"))}}
+   render-fn]
+  ^::error-boundary {:display-name       display-name
+                     :render-fn          render-fn
+                     :did-catch          did-catch
+                     :derive-error-state derive-error-state})
+
 ;; === Hooks ===
 
 (defn vector->js-array [coll]

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -43,7 +43,7 @@
 (deftest test-defui
   (defui h1 [{:keys [children]}]
     ($ :h1 {} children))
-  (is (= (t/as-string ($ h1 {} 1))) "<h1>1</h1>"))
+  (is (= (t/as-string ($ h1 {} 1)) "<h1>1</h1>")))
 
 (deftest test-jsfy-deps
   (is (= [1 "str" "k/w" "uix.core/sym" "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -208,5 +208,65 @@
       (is (= "<button title=\"hey\">hey</button>"
              (t/as-string ($ as {:title "hey"} "hey")))))))
 
+(defonce *error-state (atom nil))
+
+(def error-boundary
+  (uix.core/create-error-boundary
+   {:derive-error-state (fn [error]
+                          {:error error})
+    :did-catch          (fn [error info]
+                          (reset! *error-state error))}
+   (fn [[state _set-state!] {:keys [children]}]
+     (if (:error state)
+       ($ :p "Error")
+       children))))
+
+(defui throwing-component [{:keys [throw?]}]
+  (when throw?
+    (throw "Component throws")))
+
+(defui error-boundary-no-elements []
+  ($ throwing-component {:throw? false}))
+
+(defui error-boundary-catches []
+  ($ error-boundary
+     ($ throwing-component {:throw? true})))
+
+(defui error-boundary-renders []
+  ($ error-boundary
+     ($ throwing-component {:throw? false})
+     ($ :p "After")))
+
+(defui error-boundary-children []
+  ($ error-boundary
+     ($ throwing-component {:throw? false})
+     ($ :p "After throwing")
+     ($ :p "After throwing 2")))
+
+(deftest ssr-error-boundaries
+  (let [root (js/document.createElement "div")]
+    (react-dom/render ($ error-boundary-no-elements) root)
+    (is (= (.-textContent root)  ""))
+    (react-dom/unmountComponentAtNode root)
+
+    (react-dom/render ($ error-boundary-catches) root)
+    (is (= (.-textContent root) "Error"))
+    (react-dom/unmountComponentAtNode root)
+
+    (react-dom/render ($ error-boundary-renders) root)
+    (is (= (.-textContent root) "After"))
+    (react-dom/unmountComponentAtNode root)
+
+    (react-dom/render ($ error-boundary-children) root)
+    (is (= (.-textContent root) "After throwingAfter throwing 2"))
+    (react-dom/unmountComponentAtNode root)))
+
+(deftest ssr-error-boundary-catch-fn
+  (reset! *error-state nil)
+  (let [root (js/document.createElement "div")
+        _    (react-dom/render ($ error-boundary-catches) root)]
+    ;; Tests that did-catch does run
+    (is (str/includes? @*error-state "Component throws"))))
+
 (defn -main []
   (run-tests))


### PR DESCRIPTION
- Error boundary support for both cljs and JVM
- Tests for both platforms
- Documentation for error boundary recipe

I'm pretty much done with this one @roman01la . The only thing I'm not too happy about is having to access the `children` prop on the cljs side - `(.-children children)`. Not entirely sure how to work around this. I guess we could do it automatically during the `render-fn` call? 

```clojure
(def error-boundary
  (uix.core/create-error-boundary
   {:derive-error-state (fn [error]
                          {:error error})
    :did-catch          (fn [error info]
                          (reset! *error-state error))}
   (fn [state [children]]
     (if (:error @state)
       ($ :p "Error")
       (.-children children)))))
```