### PR TITLE
Don't throw on nil :__html value

### DIFF
--- a/dom/src/uix/dom/server.clj
+++ b/dom/src/uix/dom/server.clj
@@ -396,9 +396,10 @@
   (when-let [inner-html (:dangerouslySetInnerHTML attrs)]
     (when-not (empty? children)
       (throw (Exception. "Invariant Violation: Can only set one of `children` or `props.dangerouslySetInnerHTML`.")))
-    (when-not (:__html inner-html)
+    (when-not (contains? inner-html :__html)
       (throw (Exception. "Invariant Violation: `props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.")))
-    (append! sb (:__html inner-html))
+    (when-not (nil? (:__html inner-html))
+      (append! sb (:__html inner-html)))
     true))
 
 (defn render-textarea-value! [tag attrs sb]

--- a/dom/test/uix/dom/server_test.cljc
+++ b/dom/test/uix/dom/server_test.cljc
@@ -403,3 +403,14 @@
      (let [_ (render ($ error-boundary-catches))]
        ;; Tests that did-catch does run
        (is (.contains @*error-state "error-boundary")))))
+
+(defui username [{:keys [username]}]
+  ($ :p {:dangerouslySetInnerHTML {:__html username}}))
+
+(defui bad-username [_]
+  ($ :p {:dangerouslySetInnerHTML {:__not-html "foo"}}))
+
+#?(:clj
+   (deftest nil-dangerously-set-inner-html
+     (is (= (render ($ username {:username nil})) "<p></p>"))
+     (is (thrown? Exception (render ($ bad-username {:foo 1}))))))


### PR DESCRIPTION
This fixes #101 

This is how React handles `nil` from [what](https://github.com/facebook/react/blob/0ffc7f632b5cdc2d4ede97b6f8ff55e02183bdf9/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js#L802) I can [see](https://github.com/facebook/react/blob/0ffc7f632b5cdc2d4ede97b6f8ff55e02183bdf9/CHANGELOG.md?plain=1#L260)

Added tests cases for both paths!