### PR TITLE
Match JVM use-state return type with JS return type

### DIFF
--- a/core/src/uix/hooks/alpha.clj
+++ b/core/src/uix/hooks/alpha.clj
@@ -8,7 +8,7 @@
 
 ;; == State hook ==
 (defn use-state [value]
-  value)
+  [value #(no-op "set-state" %1)])
 
 (defn use-reducer
   ([f value]


### PR DESCRIPTION
This PR fixes `use-state` so that the return type matches the type in JS. 

You get this sort of exception if you try to use SSR `use-state`:
![Screenshot 2023-04-20 at 09 02 38](https://user-images.githubusercontent.com/11030306/233287483-74da143d-7ece-4f32-a12c-35a87085f9f6.png)
