### PR TITLE
Add helper to detect UIx components

### DIFF
--- a/core/src/uix/dev.cljs
+++ b/core/src/uix/dev.cljs
@@ -18,3 +18,8 @@
   "Should be called after hot-reload, in shadow's ^:dev/after-load hook"
   []
   (refresh/performReactRefresh))
+
+(defn uix-component?
+  "Returns true, if `f` is a UIx component created by `defui` or `uix/fn`"
+  [^js f]
+  (true? (.-uix-component? f)))


### PR DESCRIPTION
This PR adds `uix.dev/uix-component?` as a convenience function to check for components created by `defying` or `uix.core/fn`.

This comes in especially handy for defining specs

```cljs
(s/def ::my-component uix.dev/uix-component?)
```