### PR TITLE
Don't inject forward ref if key already exists in props

### DIFF
--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -261,7 +261,7 @@
          (fn [props ref]
            (let [argv (cond-> (.-argv props)
                         (.-children props) (assoc :children (.-children props))
-                        :always (assoc :ref ref))
+                        (nil? (:ref (.-argv props))) (assoc :ref ref))
                  argv (merge argv
                              (-> (bean/bean props)
                                  (dissoc [:argv :children])))]


### PR DESCRIPTION
This is so that we can pass in our own `ref` as part of props when using forward refs, and control the ref being passed to the component.