### PR TITLE
add utilities for html and hiccup to uix conversion

### DIFF
--- a/core/deps.edn
+++ b/core/deps.edn
@@ -1,4 +1,5 @@
-{:deps {cljs-bean/cljs-bean {:mvn/version "1.9.0"}}
+{:deps {cljs-bean/cljs-bean {:mvn/version "1.9.0"}
+        org.clj-commons/hickory {:mvn/version "0.7.3"}}
  :paths ["src" "resources"]
  :aliases {:dev {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}}
            :benchmark {:extra-paths ["benchmark"]

--- a/dom/test/uix/dom/linter_test.cljc
+++ b/dom/test/uix/dom/linter_test.cljc
@@ -6,18 +6,18 @@
                     [shadow.cljs.devtools.cli])))
 
 #?(:clj
-    (deftest test-dom-linter
-      (let [out-str (with-out-str (shadow.cljs.devtools.cli/-main "compile" "linter-test"))]
-        (testing "should fail on invalid DOM property"
-          (is (str/includes? out-str "Invalid DOM property :autoplay. Did you mean :auto-play?")))
-        (testing "should not fail on invalid DOM property"
-          (is (not (str/includes? out-str "Invalid DOM property :auto-play"))))
-        (testing "should not fail on aliased DOM property"
-          (is (not (str/includes? out-str "Invalid DOM property :class")))
-          (is (not (str/includes? out-str "Invalid DOM property :for")))
-          (is (not (str/includes? out-str "Invalid DOM property :charset")))
-          (is (not (str/includes? out-str "Invalid DOM property :class-id")))
-          (is (not (str/includes? out-str "Invalid DOM property :item-id")))))))
+   (deftest test-dom-linter
+     (let [out-str (with-out-str (shadow.cljs.devtools.cli/-main "compile" "linter-test"))]
+       (testing "should fail on invalid DOM property"
+         (is (str/includes? out-str "Invalid DOM property :autoplay. Did you mean :auto-play?")))
+       (testing "should not fail on invalid DOM property"
+         (is (not (str/includes? out-str "Invalid DOM property :auto-play"))))
+       (testing "should not fail on aliased DOM property"
+         (is (not (str/includes? out-str "Invalid DOM property :class")))
+         (is (not (str/includes? out-str "Invalid DOM property :for")))
+         (is (not (str/includes? out-str "Invalid DOM property :charset")))
+         (is (not (str/includes? out-str "Invalid DOM property :class-id")))
+         (is (not (str/includes? out-str "Invalid DOM property :item-id")))))))
 
 #?(:cljs
    (do


### PR DESCRIPTION
```clojure
;; input
(hiccup->uix
   [:div
    [:div {:class "foo"} "bar"]
    [:> 'js-component]
    [:<> [:button "hello"] [:span "world"]]
    ^{:key "hello"} [:span "world"]])

;; output
($ :div
 ($ :div {:class "foo"} "bar")
 ($ js-component)
 ($ :<> ($ :button "hello") ($ :span "world"))
 ($ :span {:key "hello"} "world"))

;; input
(html->uix
   "<p class=\"c-fDhfVa c-fDhfVa-dkirSI-spaced-true c-fDhfVa-jFCKZD-family-default c-fDhfVa-grGuE-size-3 c-fDhfVa-hYBDYy-variant-default c-fDhfVa-kHnRXL-weight-2\">Finally, one last scene, just for fun! I ported to React Three Fiber a Three.js demo from <a href=\"http://barradeau.com/blog/?p=621\" class=\"c-iNkjEl c-iNkjEl-dNnDWN-underline-true c-iNkjEl-igJWTOZ-css\">an article</a> written by <a href=\"https://twitter.com/nicoptere\" class=\"c-iNkjEl c-iNkjEl-hGYKvZ-discreet-true c-iNkjEl-goIlEV-favicon-true c-iNkjEl-idwngVA-css\">@nicoptere</a> that does a pretty good job at deep diving into the FBO technique.</p>")

;; output
(($ :p
  {:class "c-fDhfVa c-fDhfVa-dkirSI-spaced-true c-fDhfVa-jFCKZD-family-default c-fDhfVa-grGuE-size-3 c-fDhfVa-hYBDYy-variant-default c-fDhfVa-kHnRXL-weight-2"}
  "Finally, one last scene, just for fun! I ported to React Three Fiber a Three.js demo from "
  ($ :a {:href "http://barradeau.com/blog/?p=621"
         :class "c-iNkjEl c-iNkjEl-dNnDWN-underline-true c-iNkjEl-igJWTOZ-css"}
   "an article")
  " written by "
  ($ :a {:href "https://twitter.com/nicoptere",
         :class "c-iNkjEl c-iNkjEl-hGYKvZ-discreet-true c-iNkjEl-goIlEV-favicon-true c-iNkjEl-idwngVA-css"}
   "@nicoptere")
  " that does a pretty good job at deep diving into the FBO technique."))
```