### PR TITLE
Add defhook to lint as defn in clj-kondo config

### DIFF
--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
@@ -1,6 +1,7 @@
-{:lint-as {uix.core/fn    clojure.core/fn
-           uix.core/defui clojure.core/defn
-           uix.core/$     hooks.uix/$}
+{:lint-as {uix.core/fn      clojure.core/fn
+           uix.core/defui   clojure.core/defn
+           uix.core/$       hooks.uix/$
+           uix.core/defhook clojure.core/defn}
  :linters {:uix.core/$-arg-validation
            {:level :warning}
 


### PR DESCRIPTION
Using defhook was showing an error in clj-kondo, added the config to clj-kondo config to lint defhook as defn