### PR TITLE
make args optional in clj components

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -86,8 +86,9 @@
            (set! (.-uix-component? ~var-sym) true)
            (set! (.-displayName ~var-sym) ~(str var-sym))
            ~(uix.dev/fast-refresh-signature var-sym body)))
-      `(defn ~fname ~args
-         ~@fdecl))))
+      `(defn ~fname [& args#]
+         (let [~args args#]
+           ~@fdecl)))))
 
 (defmacro fn
   "Creates anonymous UIx component. Similar to fn, but doesn't support multi arity.
@@ -106,8 +107,9 @@
            (set! (.-uix-component? ~var-sym) true)
            (set! (.-displayName ~var-sym) ~(str var-sym))
            ~var-sym))
-      `(core/fn ~fname ~args
-         ~@fdecl))))
+      `(core/fn ~fname [& args#]
+         (let [~args args#]
+           ~@fdecl)))))
 
 (defmacro source
   "Returns source string of UIx component"

--- a/dom/test/uix/dom/server_test.cljc
+++ b/dom/test/uix/dom/server_test.cljc
@@ -56,6 +56,19 @@
        (:x props))
      (is (= "hello" (render ($ test-defui-comp-1 {:x "hello" :key "k" :ref 1} "child" "more"))))))
 
+#?(:clj
+   (deftest test-no-args-component
+     (testing "no args defui"
+       (uix.core/defui args-not-required-component [{:keys [children]}]
+         ($ :h1 children))
+       (is (= "<h1></h1>"
+              (render (uix.core/$ args-not-required-component)))))
+     (testing "no args fn"
+       (is (= "<h1></h1>"
+              (render (uix.core/$ (uix.core/fn [{:keys [children]}]
+                                    ($ :h1 children)))))))))
+
+
 ;; Adapted from https://github.com/tonsky/rum/blob/gh-pages/test/rum/test/server_render.cljc
 
 (defui comp-simple []


### PR DESCRIPTION
as per bug report
```
Server-side rendering: Component with optional children cannot render without argument
I have this component that takes optional children
(defui head
  "Contains head components, related to the document such as style and meta elements"
  ([{:keys [children] :as props}]
   ($ :head (dissoc props :children)
      ($ :meta {:content "text/html; charset=utf-8"
                :http-equiv "Content-Type"})
      ($ :meta {:name "x-apple-disable-message-reformatting"})
      children)))
I want to render like ($ head) but I get an error Wrong number of args passed to head
It’s fixed if I do ($ head "") but it doesn’t feel necessary. The equivalent in React or JSX <Head /> would work without passing mandatory children
```