### PR TITLE
use clj eq check in hooks with deps

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -208,18 +208,15 @@
   ([subscribe get-snapshot get-server-snapshot]
    (hooks/use-sync-external-store subscribe get-snapshot get-server-snapshot)))
 
-(defn vector->js-array [coll]
-  (cond
-    (vector? coll) `(jsfy-deps (cljs.core/array ~@coll))
-    (some? coll) `(jsfy-deps ~coll)
-    :else coll))
+(defn ->js-deps [coll]
+  `(cljs.core/array (uix.hooks.alpha/use-clj-deps ~coll)))
 
 (defn- make-hook-with-deps [sym env form f deps]
   (when (uix.lib/cljs-env? env)
     (uix.linter/lint-exhaustive-deps! env form f deps))
   (if deps
     (if (uix.lib/cljs-env? env)
-      `(~sym ~f ~(vector->js-array deps))
+      `(~sym ~f ~(->js-deps deps))
       `(~sym ~f ~deps))
     `(~sym ~f)))
 
@@ -277,7 +274,7 @@
   ([ref f deps]
    (when (uix.lib/cljs-env? &env)
      (uix.linter/lint-exhaustive-deps! &env &form f deps))
-   `(uix.hooks.alpha/use-imperative-handle ~ref ~f ~(vector->js-array deps))))
+   `(uix.hooks.alpha/use-imperative-handle ~ref ~f ~(->js-deps deps))))
 
 (defui suspense [{:keys [children]}]
   children)

--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -194,25 +194,6 @@
   [f]
   #(f (bean/bean %)))
 
-(defn- stringify-clojure-primitives [v]
-  (cond
-    ;; fast direct lookup for a string value
-    ;; already stored on the instance of the known type
-    (keyword? v) (.-fqn v)
-    (uuid? v) (.-uuid v)
-    (symbol? v) (.-str v)
-    :else v))
-
-(defn jsfy-deps [coll]
-  (if (or (js/Array.isArray coll)
-          (vector? coll))
-    (reduce (fn [arr v]
-              (.push arr (stringify-clojure-primitives v))
-              arr)
-            #js []
-            coll)
-    coll))
-
 (defn- lazy-shadow-reloadable
   "Special case for traditional hot-reloading via shadow-cljs,
   when UI tree is rendered from the root after evert hot-reload"

--- a/core/src/uix/hooks/alpha.cljs
+++ b/core/src/uix/hooks/alpha.cljs
@@ -2,19 +2,14 @@
   "Wrappers for React Hooks"
   (:require [react :as r]))
 
-(defn- clojure-primitive? [v]
-  (or (keyword? v)
-      (uuid? v)
-      (symbol? v)))
-
 (defn- choose-value [nv cv]
-  (if (and (clojure-primitive? nv) (= nv cv))
+  (if (= nv cv)
     cv
     nv))
 
-(defn- use-clojure-primitive-aware-updater
-  "Replicates React's behaviour when updating state with identical primitive JS type,
-  but for keywords, UUIDs and symbols that are in fact non-primitives"
+(defn- use-clojure-aware-updater
+  "Replicates React's behaviour when updating state with identical JS value,
+  but using Clojure's value equality here"
   [updater]
   (react/useCallback
    (fn [v]
@@ -29,10 +24,10 @@
 
 (defn use-state [value]
   (let [[state set-state] (r/useState value)
-        set-state (use-clojure-primitive-aware-updater set-state)]
+        set-state (use-clojure-aware-updater set-state)]
     #js [state set-state]))
 
-(defn- clojure-primitive-aware-reducer-updater
+(defn- clojure-aware-reducer-updater
   "Same as `use-clojure-primitive-aware-updater` but for `use-reducer`"
   [f]
   (fn [state action]
@@ -40,10 +35,10 @@
 
 (defn use-reducer
   ([f value]
-   (let [updater (clojure-primitive-aware-reducer-updater f)]
+   (let [updater (clojure-aware-reducer-updater f)]
      (r/useReducer updater value)))
   ([f value init-state]
-   (let [updater (clojure-primitive-aware-reducer-updater f)]
+   (let [updater (clojure-aware-reducer-updater f)]
      (r/useReducer updater value init-state))))
 
 ;; == Ref hook
@@ -55,6 +50,12 @@
 (defn with-return-value-check [f]
   #(let [ret (f)]
      (if (fn? ret) ret js/undefined)))
+
+(defn use-clj-deps [deps]
+  (let [ref (r/useRef deps)]
+    (when (not= (.-current ref) deps)
+      (set! (.-current ref) deps))
+    (.-current ref)))
 
 (defn use-effect
   ([setup-fn]

--- a/core/test/uix/core_test.clj
+++ b/core/test/uix/core_test.clj
@@ -25,9 +25,8 @@
   (is (= "simple hook" (:doc (meta #'use-hook)))))
 
 (deftest test-vector->js-array
-  (is (= '(uix.core/jsfy-deps (cljs.core/array 1 2 3)) (uix.core/vector->js-array [1 2 3])))
-  (is (= '(uix.core/jsfy-deps x) (uix.core/vector->js-array 'x)))
-  (is (nil? (uix.core/vector->js-array nil))))
+  (is (= '(cljs.core/array (uix.hooks.alpha/use-clj-deps [1 2 3]))
+         (uix.core/->js-deps [1 2 3]))))
 
 (deftest test-$
   (testing "in cljs env"

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -45,14 +45,6 @@
     ($ :h1 {} children))
   (is (= (t/as-string ($ h1 {} 1)) "<h1>1</h1>")))
 
-(deftest test-jsfy-deps
-  (is (= [1 "str" "k/w" "uix.core/sym" "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]
-         (vec (uix.core/jsfy-deps [1 "str" :k/w 'uix.core/sym #uuid "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]))))
-  (is (= [1 "str" "k/w" "uix.core/sym" "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]
-         (vec (uix.core/jsfy-deps #js [1 "str" :k/w 'uix.core/sym #uuid "b53887c9-4910-4d4e-aad9-f3487e6e97f5" nil [] {} #{}]))))
-  (is (= #{} (uix.core/jsfy-deps #{})))
-  (is (= {} (uix.core/jsfy-deps {}))))
-
 (deftest test-lazy
   (async done
          (let [expected-value :x

--- a/core/test/uix/hooks_test.cljs
+++ b/core/test/uix/hooks_test.cljs
@@ -15,6 +15,22 @@
     (let [f (hooks/with-return-value-check (constantly identity))]
       (is (= identity (f))))))
 
+(deftest test-use-clj-deps
+  (let [ov [1 2 3]
+        result (rtl/renderHook
+                 #(hooks/use-clj-deps %)
+                 #js {:initialProps ov})
+        rerender (.-rerender result)
+        result (.-result result)
+        v (.-current result)
+        _ (is (identical? v ov))
+        _ (rerender ov)
+        v (.-current result)
+        _ (is (identical? v ov))
+        _ (rerender {:k :v})
+        v (.-current result)
+        _ (is (= v {:k :v}))]))
+
 (deftest test-use-state
   (let [[v f] (render-hook #(uix/use-state 0))]
     (is (zero? v))))
@@ -24,9 +40,23 @@
                          (let [[v f] (uix/use-state 0)]
                            (uix/use-effect #(f inc) [])
                            v)))]
-    (is (= 1 v))))
+    (is (= 1 v)))
+  (testing "clj dep"
+    (let [result (rtl/renderHook
+                   (fn [dep]
+                     (let [[v f] (uix/use-state 0)]
+                       (uix/use-effect #(f inc) [dep])
+                       v))
+                   #js {:initialProps {:k :v}})
+          rerender (.-rerender result)
+          result (.-result result)]
+      (is (= 1 (.-current result)))
+      (rerender {:k :v})
+      (is (= 1 (.-current result)))
+      (rerender {:k :vv})
+      (is (= 2 (.-current result))))))
 
-(deftest test-clojure-primitives-identity-use-state
+(deftest test-clojure-values-identity-use-state
   (testing "UUID: should preserve identity"
     (let [uuid1 #uuid "b137e2ea-a419-464f-8da3-7159005afa35"
           uuid2 (render-hook (fn []
@@ -48,15 +78,15 @@
                                 (uix/use-effect #(f (constantly 'hello-world)) [])
                                 v)))]
       (is (identical? sym1 sym2))))
-  (testing "Map: should not preserve identity"
+  (testing "Map: should preserve identity"
     (let [m1 {:hello 'world}
           m2 (render-hook (fn []
                             (let [[v f] (uix/use-state m1)]
                               (uix/use-effect #(f {:hello 'world}) [])
                               v)))]
-      (is (not (identical? m1 m2))))))
+      (is (identical? m1 m2)))))
 
-(deftest test-clojure-primitives-identity-use-reducer
+(deftest test-clojure-values-identity-use-reducer
   (testing "UUID: should preserve identity"
     (let [uuid1 #uuid "b137e2ea-a419-464f-8da3-7159005afa35"
           uuid2 (render-hook (fn []
@@ -78,11 +108,11 @@
                                 (uix/use-effect #(f 'hello-world) [])
                                 v)))]
       (is (identical? sym1 sym2))))
-  (testing "Map: should not preserve identity"
+  (testing "Map: should preserve identity"
     (let [m1 {:hello 'world}
           m2 (render-hook (fn []
                             (let [[v f] (uix/use-reducer (fn [state action] action) m1)]
                               (uix/use-effect #(f {:hello 'world}) [])
                               v)))]
-      (is (not (identical? m1 m2))))))
+      (is (identical? m1 m2)))))
 


### PR DESCRIPTION
This won't rerun a hook now, since `use-effect` is checking deps with `cljs.core/=`
```clojure
(defui component []
  (let [val {:k :v}]
    (uix/use-effect
      (fn []
        (prn val))
      [val])))
```