### PR TITLE
redefine component fn name with unmunged var name

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -67,6 +67,11 @@
             "If you meant to retrieve `children`, they are under `:children` field in props map."))
       [fname args fdecl])))
 
+(defn- set-display-name [f name]
+  `(do
+     (set! (.-displayName ~f) ~name)
+     (js/Object.defineProperty ~f "name" (cljs.core/js-obj "value" ~name))))
+
 (defmacro
   ^{:arglists '([name doc-string? attr-map? [params*] prepost-map? body]
                 [name doc-string? attr-map? ([params*] prepost-map? body) + attr-map?])}
@@ -90,7 +95,7 @@
               (no-args-component memo-fname memo-var-sym body)
               (with-args-component memo-fname memo-var-sym args body))
            (set! (.-uix-component? ~memo-var-sym) true)
-           (set! (.-displayName ~memo-var-sym) ~(str var-sym))
+           ~(set-display-name memo-var-sym (str var-sym))
            ~(uix.dev/fast-refresh-signature memo-var-sym body)
            ~(when memo?
               `(def ~fname (uix.core/memo ~memo-sym)))))
@@ -113,7 +118,7 @@
                            (no-args-fn-component fname var-sym body)
                            (with-args-fn-component fname var-sym args body))]
            (set! (.-uix-component? ~var-sym) true)
-           (set! (.-displayName ~var-sym) ~(str var-sym))
+           ~(set-display-name var-sym (str var-sym))
            ~var-sym))
       `(core/fn ~fname [& args#]
          (let [~args args#]

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -316,5 +316,16 @@
         (is (= 3 (aget (.. el -props) "data-id")))
         (is (= "child2" (aget (.. el -props -children) 0)))))))
 
+(deftest test-component-fn-name
+  (testing "defui name"
+    (defui component-fn-name [])
+    (is (= "uix.core-test/component-fn-name"
+           (.-name component-fn-name))))
+  (testing "fn name"
+    (let [f1 (uix.core/fn component-fn-name [])
+          f2 (uix.core/fn [])]
+      (is (= "component-fn-name" (.-name f1)))
+      (is (str/starts-with? (.-name f2) "uix-fn")))))
+
 (defn -main []
   (run-tests))


### PR DESCRIPTION
before
<img width="442" alt="Screenshot 2024-11-03 at 23 03 53" src="https://github.com/user-attachments/assets/52138f2d-a3c9-40aa-8f9b-c2a930de9a8e">

after
<img width="463" alt="Screenshot 2024-11-03 at 23 03 32" src="https://github.com/user-attachments/assets/2be77ade-8a3e-4957-80e0-a6d8f33f83ef">
