### PR TITLE
Fix clj-kondo custom $ hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .idea
 *.iml
 .nrepl-port
-.clj-kondo
-.lsp
+.clj-kondo/.cache
+.lsp/.cache
 node_modules
 .cpcache
 .shadow-cljs

--- a/core/.clj-kondo/config.edn
+++ b/core/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/com.pitch/uix.core"]}

--- a/core/.clojure-lsp/config.edn
+++ b/core/.clojure-lsp/config.edn
@@ -1,0 +1,3 @@
+{;; The lib config is already included in :config-paths, no need to copy the
+ ;; local config under .clj-kondo folder.
+ :copy-kondo-configs? false}

--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/config.edn
@@ -1,7 +1,7 @@
 {:lint-as {uix.core/fn      clojure.core/fn
            uix.core/defui   clojure.core/defn
-           uix.core/$       hooks.uix/$
            uix.core/defhook clojure.core/defn}
+ :hooks {:analyze-call {uix.core/$ hooks.uix/$}}
  :linters {:uix.core/$-arg-validation
            {:level :warning}
 


### PR DESCRIPTION
Also setup clojure-lsp and clj-kondo config to make it easier to run clj-kondo in the uix core project.

`:lint-as` is only used to tell clj-kondo to use built-in hooks to lint custom macros. To run the custom hook code, like we have for `$` to check the first argument is symbol or keyword, it should use `:analyze-call` option.

Previously

```
❯ cat test/uix/dsfsdf.cljs
(ns uix.dsfsdf
  (:require [uix.core :refer [$ defui]]))

(defui foo []
  ($ 55))

❯ clj-kondo --debug --lint test/uix/dsfsdf.cljs
[clj-kondo] Linting file: test/uix/dsfsdf.cljs
linting took 17ms, errors: 0, warnings: 0
```

After fix:

```
❯ clj-kondo --debug --lint test/uix/dsfsdf.cljs
[clj-kondo] Linting file: test/uix/dsfsdf.cljs
test/uix/dsfsdf.cljs:5:3: warning: First arg to $ must be a symbol or keyword
linting took 21ms, errors: 0, warnings: 1
```