### PR TITLE
add use-effect-event-hook

### DIFF
--- a/core/dev/uix/examples.cljs
+++ b/core/dev/uix/examples.cljs
@@ -121,17 +121,16 @@
 (defui ^:memo edit-layer [{:keys [mx my on-object-changed on-select idx selected size]}]
   (let [[active? set-active] (uix/use-state false)
         selected? (some? selected)
-        on-move (uix/use-callback
+        on-move (uix/use-effect-event
                   (fn [x y]
-                    (on-object-changed idx (assoc selected :x x :y y)))
-                  [idx selected on-object-changed])
+                    (on-object-changed idx (assoc selected :x x :y y))))
         on-resize (fn [object idx width height]
                     (on-object-changed idx (assoc object :width width :height height)))]
 
     (uix/use-effect
       #(when active?
          (on-move mx my))
-      [selected? active? mx my on-move])
+      [selected? active? mx my])
 
     (uix/use-effect
       #(when selected?

--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -278,6 +278,13 @@
   [f deps]
   (make-hook-with-deps 'uix.hooks.alpha/use-callback &env &form f deps))
 
+(defn use-effect-event
+  "EXPERIMENTAL: Creates a stable event handler from a function, allowing it to be used in use-effect
+   without adding the function as a dependency.
+  See: https://react.dev/learn/separating-events-from-effects"
+  [f]
+  f)
+
 (defmacro use-imperative-handle
   "Customizes the instance value that is exposed to parent components when using ref.
 

--- a/core/src/uix/core.cljs
+++ b/core/src/uix/core.cljs
@@ -174,6 +174,15 @@
   []
   (hooks/use-id))
 
+(defn use-effect-event
+  "EXPERIMENTAL: Creates a stable event handler from a function, allowing it to be used in use-effect
+   without adding the function as a dependency.
+  See: https://react.dev/learn/separating-events-from-effects"
+  [f]
+  (let [ref (use-ref nil)]
+    (reset! ref f)
+    (uix.core/use-callback (fn [& args] (apply @ref args)) [])))
+
 (defn use-sync-external-store
   "For reading and subscribing from external data sources in a way that’s compatible
   with concurrent rendering features like selective hydration and time slicing.

--- a/core/src/uix/linter.clj
+++ b/core/src/uix/linter.clj
@@ -373,8 +373,8 @@
                              ("use-state" "useState" "use-reducer" "useReducer")
                              (str "`" sym "` is an unnecessary dependency because it's a state updater function with a stable identity")
 
-                             ("use-event" "useEvent")
-                             (str "`" sym "` is an unnecessary dependency because it's a function created using useEvent hook that has a stable identity")
+                             ("use-event" "useEvent" "use-effect-event" "useEffectEvent")
+                             (str "`" sym "` is an unnecessary dependency because it's a function created using useEffectEvent hook that has a stable identity")
 
                              nil)))
                    (str/join "\n"))
@@ -446,7 +446,8 @@
   #{"use-state" "useState"
     "use-reducer" "useReducer"
     "use-ref" "useRef"
-    "use-event" "useEvent"})
+    "use-event" "useEvent"
+    "use-effect-event" "useEffectEvent"})
 
 (defn find-unnecessary-deps [env deps]
   (keep (fn [sym]


### PR DESCRIPTION
A hook that detaches event handler from reactive requirements of effect hooks https://react.dev/learn/separating-events-from-effects