### PR TITLE
ssr: streaming with suspense

### DIFF
--- a/core/src/uix/core.clj
+++ b/core/src/uix/core.clj
@@ -298,8 +298,8 @@
      (uix.linter/lint-exhaustive-deps! &env &form f deps))
    `(uix.hooks.alpha/use-imperative-handle ~ref ~f ~(->js-deps deps))))
 
-(defui suspense [{:keys [children]}]
-  children)
+(defui suspense [{:keys [fallback children]}]
+  [::suspense fallback children])
 
 (defui strict-mode [{:keys [children]}]
   children)

--- a/dom/deps.edn
+++ b/dom/deps.edn
@@ -1,8 +1,13 @@
-{:deps {}
+{:deps {org.clojure/core.async {:mvn/version "1.6.681"}}
  :paths ["src"]
- :aliases {:dev {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}
+ :aliases {:dev {:extra-paths ["dev"]
+                 :extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}
                               org.clojure/clojurescript {:mvn/version "1.10.879"}
-                              uix.core/uix.core {:local/root "../core"}}}
+                              uix.core/uix.core {:local/root "../core"}
+                              http-kit/http-kit {:mvn/version "2.8.0"}
+                              compojure/compojure {:mvn/version "1.7.1"}
+                              thheller/shadow-cljs {:mvn/version "2.15.5"}
+                              com.cognitect/transit-cljs {:mvn/version "0.8.280"}}}
            :test {:extra-paths ["test"]
                   :extra-deps {clj-diffmatchpatch/clj-diffmatchpatch {:mvn/version "0.0.9.3"}
                                thheller/shadow-cljs {:mvn/version "2.15.5"}}}

--- a/dom/dev/example/core.clj
+++ b/dom/dev/example/core.clj
@@ -1,0 +1,44 @@
+(ns example.core
+  (:require [uix.dom.server :as dom.server]
+            [uix.core :as uix :refer [defui $]]
+            [org.httpkit.server :as server]
+            [compojure.core :refer [defroutes GET]]
+            [compojure.route :as route]
+            [example.ui :as ui]))
+
+(defn page [{:keys [children]}]
+  ($ :html
+     ($ :head
+        ($ :title "Hello, world!"))
+     ($ :body
+        ($ :#root
+           children)
+        ($ :script {:src "/main.js"}))))
+
+(defn handler [request]
+  (server/as-channel request
+    {:on-open (fn [ch]
+                (dom.server/render-to-stream ($ page ($ ui/app))
+                  {:on-chunk
+                   (fn [chunk]
+                     (server/send! ch chunk false))
+                   :on-done
+                   (fn []
+                     (server/close ch))}))}))
+
+(defroutes server-routes*
+  (GET "/" req
+    (handler req))
+  (route/files "/" {:root "out"})
+  (route/not-found "<p>Page not found.</p>"))
+
+(defn start-server []
+  (server/run-server #'server-routes* {:port 9090}))
+
+(defn -main [& args]
+  (start-server)
+  (println "Server started on http://localhost:9090"))
+
+(comment
+  (def stop-server (start-server))
+  (stop-server))

--- a/dom/dev/example/ui.cljc
+++ b/dom/dev/example/ui.cljc
@@ -1,0 +1,72 @@
+(ns example.ui
+  #?(:cljs (:require-macros [example.ui :refer [suspend]]))
+  (:require [uix.core :as uix :refer [defui $]]
+            [uix.dom.server :as dom.server]
+            #?@(:cljs [[uix.dom :as dom]])
+            [cognitect.transit :as t]
+            #?(:clj [clojure.data.json :as json]))
+  #?(:clj (:import (java.io ByteArrayInputStream ByteArrayOutputStream))))
+
+(defn write-transit [data]
+  #?(:clj (let [out (ByteArrayOutputStream.)
+                writer (t/writer out :json)]
+            (t/write writer data)
+            (str out))
+     :cljs (t/write (t/writer :json) data)))
+
+(defn read-transit [s]
+  #?(:clj (let [in (ByteArrayInputStream. (.getBytes s))
+                reader (t/reader in :json)]
+            (t/read reader))
+     :cljs (t/read (t/reader :json) s)))
+
+(defn fake-fetch [delay data]
+  ;; DB call, HTTP request, etc.
+  #?(:clj
+     (do (Thread/sleep delay)
+         data)))
+
+#?(:clj
+    (defmacro suspend [& body]
+      ;; dom.server/suspend is generic API
+      ;; you have to provide your own implementation for de/serialization
+      ;; + wrapping function should be a macro that provides code location
+      ;; where `suspend` wrapper is called, to make sure that client can read embedded server data (needs more work)
+      `(dom.server/suspend
+         {:loc ~(meta &form)
+          :write (comp json/write-str write-transit)
+          :read #(some-> % read-transit)}
+         ~@body)))
+
+(defui button [{:keys [on-click]}]
+  ($ :button {:on-click on-click}
+     (:text (suspend (fake-fetch 2000 {:text "suspended button"})))))
+
+(defui input []
+  (let [initial-value (:value (suspend (fake-fetch 4000 {:value "< suspended value >"})))
+        [value set-value] (uix/use-state initial-value)]
+    ($ :input {:value value
+               :on-change #(set-value (.. % -target -value))
+               :style {:padding "4px 12px"}})))
+
+(defui app []
+  ($ :div {:style {:font "normal 16px sans-serif"
+                   :display :flex
+                   :flex-direction :column
+                   :align-items :center
+                   :gap 16}}
+    ($ :h1 "Suspended!")
+    ($ uix/suspense {:fallback ($ :div "Loading button...")}
+      ($ button {:on-click #(prn "< suspended button >")}))
+    ($ uix/suspense {:fallback ($ :div "Loading input...")}
+      ($ input))
+    ($ :button {:on-click #(prn "< static button >")}
+       "static button")))
+
+#?(:cljs
+    (defn render []
+      (dom/hydrate-root (js/document.getElementById "root") ($ app))))
+
+#?(:cljs
+   (defn ^:dev/after-load reload []
+     (js/location.reload)))

--- a/dom/shadow-cljs.edn
+++ b/dom/shadow-cljs.edn
@@ -5,6 +5,11 @@
          :output-dir "out"
          :output-to "out/main.js"}
 
+  :ssr {:target :browser
+        :output-dir "out"
+        :modules {:main {:entries [example.ui]
+                         :init-fn example.ui/render}}}
+
   :linter-test {:target :browser
                 :output-dir "out"
                 :modules {:main {:entries [uix.dom.linter-test]}}}}}

--- a/dom/src/uix/dom/server.cljs
+++ b/dom/src/uix/dom/server.cljs
@@ -1,4 +1,5 @@
 (ns uix.dom.server
+  (:require-macros [uix.dom.server])
   (:require ["react-dom/server" :as rdom-server]))
 
 (defn render-to-string


### PR DESCRIPTION
Initial implementation of streaming SSR with suspense boundaries, as described in https://github.com/reactwg/react-18/discussions/37

- `example.core` includes web server implementation
- `example.ui` includes UI components with suspense boundaries

Running the demo
- server `cd dom && clojure -A:dev -M -m example.core`
- client `cd dom && clojure -A:dev -M -m shadow.cljs.devtools.cli watch ssr`

## Explainer

When server rendering on JVM, data dependencies are resolved synchronously, which blocks delivery of HTML to the client. Moreover, it introduces a waterfall of requests, making HTML generation even slower.

Instead, it's proposed to implement out of order streaming. We can run suspended UI concurrently (UIx elements wrapped in `suspense` component) and return initial HTML immediately. Once the suspended UI resolves, chunks of HTML are streamed to the client together with bits of JS that insert the streamed HTML into DOM at specified locations where "suspended" UI is declared.

Together with HTML and JS we also stream the data retrieved in suspended components, so that React on the client can pick it up and correctly hydrate HTML into interactive UI.

Using this approach, we are able to keep co-located data and prevent degraded user experience.

## TODO
- [x] `$!` error handling
- [ ] more robust data sharing between server and client
  - [ ] make sure it's compatible with repl workflow
- [x] tests