### PR TITLE
render context

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -24,6 +24,12 @@
     #js [component-type js-props (aget props-children 1)]
     #js [component-type js-props]))
 
+(defn- react-context? [x]
+  (identical? (aget x "$$typeof")
+              (js/Symbol.for "react.context")))
+
+
+
 (defn- pojo? [x]
   (and (not (.hasOwnProperty x "$$typeof"))
        (some-> x .-constructor (identical? js/Object))))
@@ -53,6 +59,9 @@
   (let [js-props (-> (aget props-children 0)
                      (attrs/interpret-attrs #js [] true)
                      (aget 0))
+        component-type (if (react-context? component-type)
+                         (.-Provider ^js component-type)
+                         component-type)
         args (normalise-args component-type js-props props-children)]
     (create-element args children)))
 

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -274,6 +274,17 @@
   (reset! state props)
   nil)
 
+(deftest test-render-context
+  (let [result (atom nil)
+        ctx (uix.core/create-context "hello")
+        comp (uix.core/fn []
+               (let [v (uix.core/use-context ctx)]
+                 (reset! result v)))
+        _ (rtl/render
+            ($ ctx {:value "world"}
+               ($ comp)))]
+    (is (= "world" @result))))
+
 (deftest test-forward-ref-interop
   (let [state (atom nil)
         forward-ref-interop-uix-component-ref (uix.core/forward-ref forward-ref-interop-uix-component)

--- a/core/test/uix/test_utils.cljs
+++ b/core/test/uix/test_utils.cljs
@@ -1,7 +1,7 @@
 (ns uix.test-utils
   (:require ["react-dom/server" :as rserver]
             ["react-dom/client" :as rdc]
-            ["react-dom/test-utils" :as rdt]
+            [react]
             [goog.object :as gobj]
             [clojure.test :refer [is]]
             [jsdom :refer [JSDOM]]))
@@ -44,9 +44,9 @@
    (let [node (js/document.createElement "div")
          _ (js/document.body.append node)
          root (rdc/createRoot node)]
-     (rdt/act #(.render root el))
+     (react/act #(.render root el))
      (f node)
-     (rdt/act #(.unmount root))
+     (react/act #(.unmount root))
      (after-unmount)
      (.remove node)
      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false))))


### PR DESCRIPTION
Similarly to React v19, it's now possible to render React context in UIx, regardless of React version

before
```clojure
(def ctx (uix/create-context))

($ (.-Provider ctx) {:value v}
  ...)
```

after
```clojure
(def ctx (uix/create-context))

($ ctx {:value v}
  ...)
```