### PR TITLE
do not interpret context value

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -20,7 +20,7 @@
   true)
 
 (defn- normalise-args [component-type js-props props-children]
-  (if (= 2 (.-length ^js props-children))
+  (if (== 2 (.-length ^js props-children))
     #js [component-type js-props (aget props-children 1)]
     #js [component-type js-props]))
 
@@ -55,13 +55,17 @@
         args (normalise-args component-type js-props props-children)]
     (create-element args children)))
 
+(defn- react-context-element [component-type ^js props-children children]
+  (let [component-type (.-Provider ^js component-type)
+        props (aget props-children 0)
+        js-props #js {:value (:value props)}
+        args (normalise-args component-type js-props props-children)]
+    (create-element args children)))
+
 (defn- react-component-element [component-type ^js props-children children]
   (let [js-props (-> (aget props-children 0)
                      (attrs/interpret-attrs #js [] true)
                      (aget 0))
-        component-type (if (react-context? component-type)
-                         (.-Provider ^js component-type)
-                         component-type)
         args (normalise-args component-type js-props props-children)]
     (create-element args children)))
 
@@ -83,5 +87,8 @@
 
     (keyword? component-type)
     (dynamic-element component-type props-children children)
+
+    (react-context? component-type)
+    (react-context-element component-type props-children children)
 
     :else (react-component-element component-type props-children children)))

--- a/core/test/uix/core_test.cljs
+++ b/core/test/uix/core_test.cljs
@@ -285,6 +285,18 @@
                ($ comp)))]
     (is (= "world" @result))))
 
+(deftest test-context-value-clojure-primitive
+  (let [result (atom nil)
+        ctx (uix.core/create-context :hello)
+        comp (uix.core/fn []
+               (let [v (uix.core/use-context ctx)]
+                 (reset! result v)
+                 nil))
+        _ (rtl/render
+            ($ ctx {:value :world}
+               ($ comp)))]
+    (is (= :world @result))))
+
 (deftest test-forward-ref-interop
   (let [state (atom nil)
         forward-ref-interop-uix-component-ref (uix.core/forward-ref forward-ref-interop-uix-component)


### PR DESCRIPTION
before
```clojure
(def ctx (uix/create-context))

($ (.-Provider ctx) {:value :hello} ;; :hello is converted into a string "hello"
 ...)
```

after
```clojure
(def ctx (uix/create-context))

($ (.-Provider ctx) {:value :hello} ;; Clojure's primitives are passed as is, not converted
 ...)