### PR TITLE
adapt use-reaction for Track and Cursor

### DIFF
--- a/core/deps.edn
+++ b/core/deps.edn
@@ -12,7 +12,8 @@
                                org.clojure/clojurescript {:mvn/version "1.11.60"}
                                thheller/shadow-cljs {:mvn/version "2.23.1"}
                                uix.dom/uix.dom {:local/root "../dom"}
-                               clj-diffmatchpatch/clj-diffmatchpatch {:mvn/version "0.0.9.3"}}}
+                               clj-diffmatchpatch/clj-diffmatchpatch {:mvn/version "0.0.9.3"}
+                               re-frame/re-frame {:mvn/version "1.4.3"}}}
 
            :release {:extra-paths ["dev"]
                      :extra-deps {appliedscience/deps-library {:mvn/version "0.3.4"}

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -11,7 +11,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-refresh": "^0.14.2",
-        "source-map-support": "^0.5.21"
+        "source-map-support": "^0.5.21",
+        "use-sync-external-store": "^1.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -811,6 +812,16 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/core/package.json
+++ b/core/package.json
@@ -6,6 +6,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-refresh": "^0.14.2",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "use-sync-external-store": "^1.4.0"
   }
 }

--- a/core/test/uix/re_frame_test.cljs
+++ b/core/test/uix/re_frame_test.cljs
@@ -1,29 +1,59 @@
 (ns uix.re-frame-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing async]]
             ["@testing-library/react" :as rtl]
             [reagent.core :as r]
-            [uix.re-frame :refer [use-reaction use-subscribe]]))
+            [reagent.impl.batching]
+            [uix.re-frame :refer [use-reaction use-subscribe]]
+            [shadow.cljs.modern :refer [js-await]]))
 
-(deftest test-use-reaction
-  (let [ref (r/atom 0)
-        result (rtl/renderHook #(use-reaction ref))
+(defn wait-frame []
+  (js/Promise. (fn [resolve _]
+                 (reagent.impl.batching/next-tick resolve))))
+
+(defn test-for-atom-like [^js source-ref ^js sink-ref f]
+  (let [result (rtl/renderHook #(use-reaction sink-ref))
         rerender (.-rerender result)
         unmount (.-unmount result)
         result (.-result result)]
-    (testing "should track ratom value"
+    (testing "should track ref value"
       (is (= 0 (.-current result)))
-      (swap! ref inc)
-      (rerender)
-      (is (= 1 (.-current result))))
-    (testing "should cleanup listeners on unmount"
-      (unmount)
-      (is (nil? (.-react-listeners ref)))
-      (is (empty? (.-watches ref))))
-    (testing "should continue tracking the same ratom"
-      (let [result (rtl/renderHook #(use-reaction ref))
-            rerender (.-rerender result)
-            result (.-result result)]
-        (is (= 1 (.-current result)))
-        (swap! ref inc)
+      (f source-ref inc)
+      (js-await [_ (wait-frame)]
         (rerender)
-        (is (= 2 (.-current result)))))))
+        (is (= 1 (.-current result)))
+        (testing "should cleanup listeners on unmount"
+          (unmount)
+          (is (nil? (.-react-listeners sink-ref)))
+          (is (empty? (.-watches sink-ref))))
+        (testing "should continue tracking the same ref"
+          (let [result (rtl/renderHook #(use-reaction sink-ref))
+                rerender (.-rerender result)
+                result (.-result result)]
+            (is (= 1 (.-current result)))
+            (f source-ref inc)
+            (js-await [_ (wait-frame)]
+              (rerender)
+              (is (= 2 (.-current result))))))))))
+
+(deftest test-use-reaction-with-reaction
+  (async done
+    (let [ref (r/atom 0)]
+      (.then (test-for-atom-like ref ref swap!)
+             done))))
+
+(deftest test-use-reaction-with-track
+  (async done
+    (let [ref1 (r/atom 0)
+          ref2 (r/atom 0)
+          sink (r/track (fn [] @ref1))
+          sink-2 (r/track! (fn [] @ref2))]
+      (-> (test-for-atom-like ref1 sink swap!)
+          (.then #(test-for-atom-like ref2 sink-2 swap!))
+          (.then done)))))
+
+(deftest test-use-reaction-with-cursor
+  (async done
+    (let [ref (r/atom {:a 0})
+          cursor (r/cursor ref [:a])]
+      (.then (test-for-atom-like ref cursor #(swap! %1 update :a %2))
+             done))))

--- a/core/test/uix/re_frame_test.cljs
+++ b/core/test/uix/re_frame_test.cljs
@@ -1,0 +1,29 @@
+(ns uix.re-frame-test
+  (:require [clojure.test :refer [deftest is testing]]
+            ["@testing-library/react" :as rtl]
+            [reagent.core :as r]
+            [uix.re-frame :refer [use-reaction use-subscribe]]))
+
+(deftest test-use-reaction
+  (let [ref (r/atom 0)
+        result (rtl/renderHook #(use-reaction ref))
+        rerender (.-rerender result)
+        unmount (.-unmount result)
+        result (.-result result)]
+    (testing "should track ratom value"
+      (is (= 0 (.-current result)))
+      (swap! ref inc)
+      (rerender)
+      (is (= 1 (.-current result))))
+    (testing "should cleanup listeners on unmount"
+      (unmount)
+      (is (nil? (.-react-listeners ref)))
+      (is (empty? (.-watches ref))))
+    (testing "should continue tracking the same ratom"
+      (let [result (rtl/renderHook #(use-reaction ref))
+            rerender (.-rerender result)
+            result (.-result result)]
+        (is (= 1 (.-current result)))
+        (swap! ref inc)
+        (rerender)
+        (is (= 2 (.-current result)))))))

--- a/core/test/uix/test_runner.cljs
+++ b/core/test/uix/test_runner.cljs
@@ -4,6 +4,7 @@
             [uix.core-test]
             [uix.compiler-test]
             [uix.hooks-test]
+            [uix.re-frame-test]
             [uix.test-utils :as t]))
 
 (defn- print-comparison [m]
@@ -35,4 +36,5 @@
    'uix.aot-test
    'uix.core-test
    'uix.compiler-test
-   'uix.hooks-test))
+   'uix.hooks-test
+   'uix.re-frame-test))


### PR DESCRIPTION
with this change `use-reaction` should work with Reagent's `Reaction`, `Track` and `Cursor` types

cc @green-coder