### PR TITLE
[kondo] Tweak $ hook

### DIFF
--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
@@ -4,7 +4,8 @@
 (defn $ [{:keys [node]}]
   (let [[sym _args] (rest (api/sexpr node))]
     (when-not (or (symbol? sym)
-                  (keyword? sym))
+                  (keyword? sym)
+                  (list? sym))
       (api/reg-finding! (-> (meta node)
-                            (merge {:message "First arg to $ must be a symbol or keyword"
+                            (merge {:message "First arg to $ must be a symbol, keyword, or dynamic element"
                                     :type    :uix.core/$-arg-validation}))))))


### PR DESCRIPTION
Fixes an issue where kondo incorrectly reported warnings with dynamic elements, e.g:

```clojure
($ (if as-child Slot :button) "Some button")
```

This is valid UIx code. The hook hasn't been updated since support for dynamic elements was added.

I'm not sure if this is the best way to do this sort of check, feedback/guidance is welcome!