### PR TITLE
fix: use direct property access for js/Symbol.for

### DIFF
--- a/core/src/uix/compiler/alpha.cljs
+++ b/core/src/uix/compiler/alpha.cljs
@@ -26,7 +26,7 @@
 
 (defn- react-context? [x]
   (identical? (aget x "$$typeof")
-              (js/Symbol.for "react.context")))
+              (.for js/Symbol "react.context")))
 
 
 


### PR DESCRIPTION
This fixes an issue when running a project's test with cljs-test-runner
with node.

This was giving "Symbol.for$ is not a function"