### PR TITLE
Update cljfmt & freeze format config

### DIFF
--- a/core/cljfmt.edn
+++ b/core/cljfmt.edn
@@ -1,0 +1,4 @@
+{:paths ["./src" "./test" "./benchmark" "../dom/src" "../dom/test"]
+ :remove-consecutive-blank-lines? false
+ :extra-indents {doseq-loop [[:block 1]]
+                 uix.core/$ [[:inner 0]]}}

--- a/core/deps.edn
+++ b/core/deps.edn
@@ -2,7 +2,7 @@
         org.clj-commons/hickory {:mvn/version "0.7.3"}
         com.adamrenklint/preo {:mvn/version "0.1.0"}}
  :paths ["src" "resources"]
- :aliases {:dev {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}
+ :aliases {:dev {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.15.3"}
                               clj-kondo/clj-kondo {:mvn/version "2025.02.20"}}}
            :benchmark {:extra-paths ["benchmark"]
                        :extra-deps {reagent/reagent {:mvn/version "2.0.0"}

--- a/core/indentation.clj
+++ b/core/indentation.clj
@@ -1,1 +1,0 @@
-{doseq-loop [[:block 1]]}

--- a/core/scripts/fmt
+++ b/core/scripts/fmt
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clojure -A:dev -M -m cljfmt.main fix --indents indentation.clj ./src ./test ../dom/src ../dom/test
+clojure -A:dev -M -m cljfmt.main fix


### PR DESCRIPTION
The current formatting setup creates a lot of diffs (with default config) and is outdated.

This PR freezes the configuration with few adjustments to minimize diffs across the codebase. I believe the main contributor should run the formatter, not me. That's why there are no diffs in this PR. Otherwise, it can be used just for future local changes.

Added `benchmark` folder to the paths.

Updated `cljfmt` to the latest version.