### PR TITLE
clj kondo hook: make component name optional for anon-fn

### DIFF
--- a/core/cljfmt.edn
+++ b/core/cljfmt.edn
@@ -1,4 +1,4 @@
-{:paths ["./src" "./test" "./benchmark" "../dom/src" "../dom/test"]
+{:paths ["./src" "./test" "./benchmark" "../dom/src" "../dom/test"  "./resources"]
  :remove-consecutive-blank-lines? false
  :extra-indents {doseq-loop [[:block 1]]
                  uix.core/$ [[:inner 0]]}}


### PR DESCRIPTION
Before the PR:
<img width="218" height="108" alt="image" src="https://github.com/user-attachments/assets/5b39f82b-cb38-465d-a239-f4cd69c478f0" />

With `Unresolved symbol: props` clj-kondo error.