### PR TITLE
Fix clj-kondo hook NPE and tighten $-missing-key heuristic

### DIFF
--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
@@ -12,7 +12,11 @@
      keep keep-indexed mapcat})
 
 (defn- uix-element? [name]
-  (= (api/resolve {:name name :call true}) '{:name $ :ns uix.core}))
+  ;; api/resolve in clj-kondo >=2025.04.07 NPEs on nil :name; older versions
+  ;; returned nil. Callstack entries for fn literals can have :name nil, so
+  ;; guard here.
+  (when name
+    (= (api/resolve {:name name :call true}) '{:name $ :ns uix.core})))
 
 (defn $ [{:keys [node]}]
   (let [[sym props :as expr] (rest (api/sexpr node))]

--- a/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
+++ b/core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj
@@ -47,13 +47,31 @@
                                 (merge {:message (cond-> (str "Invalid DOM property " k ".")
                                                          (html-attrs k) (str " Did you mean " (html-attrs k) "?"))
                                         :type    :uix.dom/$-invalid-attribute}))))))
-    (when (->> (api/callstack)
-               (some #(and (contains? '#{cljs.core clojure.core} (:ns %))
-                           (contains? mapping-forms (:name %)))))
-      (when-not (->> (api/callstack)
-                     (take-while #(not (and (contains? '#{cljs.core clojure.core} (:ns %))
-                                            (contains? mapping-forms (:name %)))))
-                     (some #(uix-element? (:name %))))
+    (let [cs (api/callstack)
+          mapping-form? (fn [c]
+                          (and (contains? '#{cljs.core clojure.core} (:ns c))
+                               (contains? mapping-forms (:name c))))
+          ;; Forms whose return is one of their sub-expressions' returns — the
+          ;; $ below could still be the mapping fn's actual return.
+          return-path-form? (fn [c]
+                              (and (contains? '#{cljs.core clojure.core} (:ns c))
+                                   (contains? '#{fn fn* defn defn-
+                                                 do let let* loop
+                                                 when when-not when-let when-some when-first
+                                                 if if-not if-let if-some
+                                                 cond condp case
+                                                 cond-> cond->>}
+                                              (:name c))))
+          ;; Slice between us and the nearest mapping form. If every frame is a
+          ;; return-path form, the $ is (or could be) the direct return — a list
+          ;; item. Anything else (:vector, :map, :let-bindings, assoc/merge/...)
+          ;; means the $ is buried in constructed data and isn't itself a list item.
+          path-to-mapping (take-while (complement mapping-form?) cs)
+          on-return-path? (every? return-path-form? path-to-mapping)
+          wrapped-by-$? (some #(uix-element? (:name %)) path-to-mapping)]
+      (when (and (some mapping-form? cs)
+                 on-return-path?
+                 (not wrapped-by-$?))
         (when (or (and (map? props) (not (contains? props :key))) ;; ($ :a {})
                   (== 1 (count expr)) ;; ($ :a)
                   (and (list? props)


### PR DESCRIPTION
## Summary

Two bug fixes to the clj-kondo hook shipped from `core/resources/clj-kondo.exports/com.pitch/uix.core/hooks/uix.clj`, both surfaced while upgrading clj-kondo to 2026.04.15.

### 1. NPE in `uix-element?`

`clj-kondo.hooks-api/resolve` throws `NullPointerException` on `:name nil` in clj-kondo >=2025.04.07 (older versions returned `nil`). Callstack entries for fn literals can have `:name nil`, so the lookup is guarded.

Repro (unpatched hook + clj-kondo 2026.04.15):

```clojure
(ns repro (:require [uix.core :refer [$]]))
(map (fn []) [($ :div)])
```

### 2. `$-missing-key` over-fires on `$` nested in data

The old heuristic flagged any `($ ...)` whose callstack contained a mapping form (`map`, `mapv`, `for`, `reduce`, ...) and was not directly wrapped by another `$`. That false-fires whenever `($ ...)` lives in a data literal or other container inside the mapping fn, e.g.

```clojure
(map (fn [item]
       {:id (:id item)
        :element ($ svg-icon {:name \"x\"})})  ; not actually a list item
     items)
```

Only the `$` that is (or could become) the mapping fn's return value is itself rendered as a list item. The new check walks the callstack from `$` outward, stops at the nearest mapping form, and only warns when every frame in between is a return-path form (`fn`, `let`, `do`, `when`/`if`/`cond`, `cond->`, ...). Any container-building frame (`:vector`, `:map`, `assoc`, `merge`, ...) means the `$` is buried in data and is skipped.

## Test plan

No clj-kondo hook tests exist upstream (`core/test/uix/linter_test.clj` exercises the runtime `uix.linter` instead). Verified manually with clj-kondo 2026.04.15 against the patched hook:

- [x] NPE repro above no longer throws — clj-kondo emits only the expected arity error.
- [x] `$-missing-key` probe file below: exactly the two \"SHOULD FLAG\" cases warn; the four \"SHOULD SKIP\" cases and the \"SHOULD PASS\" (with `:key`) are clean.

<details>
<summary>Probe file</summary>

```clojure
(ns probe
  (:require [uix.core :refer [\$]]))

;; SHOULD FLAG — \$ is the body of map's fn, no :key
(map (fn [x] (\$ :li {:on-click #(do x)})) [1 2 3])

;; SHOULD SKIP — \$ is a value inside a data map
(map (fn [x] {:id x :element (\$ :div {:on-click #(do x)})}) [1 2 3])

;; SHOULD SKIP — \$ is inside a hiccup vector returned by map
(map (fn [x] [:tooltip {} (\$ :span {:on-click #(do x)})]) [1 2 3])

;; SHOULD SKIP — \$ is bound in let inside map's fn
(map (fn [x] (let [el (\$ :div {:on-click #(do x)})] [el])) [1 2 3])

;; SHOULD PASS — real list item with :key
(map (fn [x] (\$ :li {:key x :on-click #(do x)})) [1 2 3])

;; SHOULD SKIP — \$ as arg to assoc inside cond->
(map (fn [x] (cond-> {:id x} true (assoc :el (\$ :div {:on-click #(do x)})))) [1 2 3])

;; SHOULD FLAG — \$ inside `when`, real list item path
(map (fn [x] (when x (\$ :li {:on-click #(do x)}))) [1 2 3])
```

</details>